### PR TITLE
[Cant merge] Fixed mariadb ports mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./conf/mariadb-conf.d:/etc/mysql/conf.d
     ports:
-      - "3307:3307" #mariadb-port
+      - "3307:3306" #mariadb-port
     container_name: mariadb
 
   redis-cache:


### PR DESCRIPTION
Port mapping on mariadb container should be 3307:3306 instead of 3307:3307 because internally mariadb listens to port 3306