### PR TITLE
Updates for dbench and .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/data_dir
+/frappe-bench

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /frappe-bench/**/*
 !/frappe-bench/Procfile_docker
 !/frappe-bench/sites/common_site_config_docker.json
+/data_dir

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/frappe-bench/**/*
+!/frappe-bench/Procfile_docker
+!/frappe-bench/sites/common_site_config_docker.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - docker-compose up -d
   - docker exec -it -u root frappe bash -c "cd /home/frappe && chown -R frappe:frappe ./*"
   - docker exec -i frappe bash -c "cd .. && bench init frappe-bench --skip-bench-mkdir --skip-redis-config-generation && cd frappe-bench"
-  - docker exec -i frappe bash -c "mv Procfile_docker Procfile && mv sites/common_site_config_docker.json sites/common_site_config.json"
+  - docker exec -i frappe bash -c "cp Procfile_docker Procfile && cp sites/common_site_config_docker.json sites/common_site_config.json"
   - docker exec -i frappe bash -c "bench new-site site1.local"
   - docker exec -i -u root frappe bash -c "echo 127.0.0.1   site1.local >> /etc/hosts"
   - sudo su -c 'echo 127.0.0.1   site1.local >> /etc/hosts'

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,14 @@ RUN apt-get install curl
 RUN curl https://deb.nodesource.com/node_6.x/pool/main/n/nodejs/nodejs_6.7.0-1nodesource1~xenial1_amd64.deb > node.deb \
  && dpkg -i node.deb \
  && rm node.deb
-RUN apt-get install -y wkhtmltopdf
+
+# Install patched wkhtmltopdf
+RUN apt-get install -y libxrender1 libxext6 xfonts-75dpi xfonts-base
+RUN wget https://github.com/frappe/wkhtmltopdf/raw/master/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz -O /tmp/wkhtmltox.tar.xz
+RUN mkdir /tmp/wkhtmltox; \
+  tar xvf /tmp/wkhtmltox.tar.xz -C /tmp; \
+  cp /tmp/wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf; \
+  chmod o+x /usr/local/bin/wkhtmltopdf
 
 USER frappe
 WORKDIR /home/frappe

--- a/dbench
+++ b/dbench
@@ -16,9 +16,9 @@ if [[ $# -eq 0 ]]; then
 
 elif [ $1 == 'init' ]
 then
-  docker exec -i -u root frappe bash -c "cd /home/frappe && chown -R frappe:frappe ./*" 
+  docker exec -i -u root frappe bash -c "cd /home/frappe && chown -R frappe:frappe ./*"
   docker exec -it frappe bash -c "cd .. && bench init frappe-bench --skip-bench-mkdir --skip-redis-config-generation && cd frappe-bench"
-  docker exec -it frappe bash -c "mv Procfile_docker Procfile && mv sites/common_site_config_docker.json sites/common_site_config.json"
+  docker exec -it frappe bash -c "cp Procfile_docker Procfile && cp sites/common_site_config_docker.json sites/common_site_config.json"
   docker exec -it -u root frappe bash -c "apt-get install vim && apt-get install sudo && usermod -aG sudo frappe && printf '# User rules for frappe\nfrappe ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/frappe"
   docker exec -it frappe bash -c "bench set-mariadb-host mariadb"
   docker exec -it frappe bash -c "bench new-site site1.local"

--- a/dbench
+++ b/dbench
@@ -18,7 +18,7 @@ elif [ $1 == 'init' ]
 then
   docker exec -i -u root frappe bash -c "cd /home/frappe && chown -R frappe:frappe ./*"
   docker exec -it frappe bash -c "cd .. && bench init frappe-bench --ignore-exist --skip-redis-config-generation && cd frappe-bench"
-  docker exec -it frappe bash -c "mv Procfile_docker Procfile && mv sites/common_site_config_docker.json sites/common_site_config.json"
+  docker exec -it frappe bash -c "cp Procfile_docker Procfile && cp sites/common_site_config_docker.json sites/common_site_config.json"
   docker exec -it -u root frappe bash -c "apt-get install vim && apt-get install sudo && usermod -aG sudo frappe && printf '# User rules for frappe\nfrappe ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/frappe"
   docker exec -it frappe bash -c "bench set-mariadb-host mariadb"
   docker exec -it frappe bash -c "bench new-site site1.local"

--- a/dbench
+++ b/dbench
@@ -33,7 +33,9 @@ else
          exit
          ;;
       c)
-         docker exec -it frappe bash -c "bench $OPTARG"
+         shift
+         bench_args="$@"
+         docker exec -it frappe bash -c "bench ${bench_args}"
          ;;
       s)
          a=$(cd frappe-bench && ls sites/*/site_config.json | grep -o '/.\+/')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - MYSQL_USER=root
     volumes:
       - ./conf/mariadb-conf.d:/etc/mysql/conf.d
+      - ./data_dir:/var/lib/mysql
     ports:
       - "3307:3306" #mariadb-port
     container_name: mariadb


### PR DESCRIPTION
The rationale for using `cp` instead of `mv` for _Procfile_ and _common_site_config.json_ is to keep the repo clean, while still being able to have _bench_ and _frappe_ stuffs in the _frappe_bench_ folder.