### PR TITLE
Updated README.md to clarify initial admin password

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ For more info on how to build this docker container refer to this [Wiki](https:/
 
 To login to Frappe / ERPNext, open your browser and go to `[your-external-ip]:8000`, probably `localhost:8000`
 
-The default username is "Administrator" and password is what you set when you created the new site.
+The default username is "Administrator" and password is what you set when you created the new site. The default admin password is set in common_site_config.json, and is set to 'admin' in this docker image. 
+
 ## Built With
 
 * [Docker](https://www.docker.com/)


### PR DESCRIPTION
it took me a long time to way to login after initially installing. I eventually found out the default by looking into closed issues on github. I just added a line to the readme to make it clear for future users to get up and running faster.