### PR TITLE
Removed innodb configs because cause error with MariaDB 10.3

### DIFF
--- a/conf/mariadb-conf.d/my.cnf
+++ b/conf/mariadb-conf.d/my.cnf
@@ -21,9 +21,6 @@ bind-address = 0.0.0.0
 
 
 [mysqld]
-innodb-file-format=barracuda
-innodb-file-per-table=1
-innodb-large-prefix=1
 character-set-client-handshake = FALSE
 character-set-server = utf8mb4
 collation-server = utf8mb4_unicode_ci


### PR DESCRIPTION
According with:

- https://discuss.erpnext.com/t/important-mariadb-version-10-3-action-required-before-update/37717

- https://github.com/frappe/bench/issues/681

this PR solved issues #40 and #3 
