### PR TITLE
Specific mariadb version to 10.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 #bench Dockerfile
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER Facgure
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #bench Dockerfile
 
 FROM ubuntu:18.04
-MAINTAINER Facgure
+MAINTAINER frappé
 
 USER root
 RUN apt-get update -y

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   mariadb:
-    image: "mariadb"
+    image: "mariadb:10.2"
     environment:
       - MYSQL_ROOT_PASSWORD=123
       - MYSQL_USER=root


### PR DESCRIPTION
Latest mariadb version is 10.3 which is not support required mariadb configuration for frappe-bench below.
```
innodb-file-format=barracuda
innodb-file-per-table=1
innodb-large-prefix=1
```