### PR TITLE
dbench: fix init issues

### DIFF
--- a/dbench
+++ b/dbench
@@ -4,7 +4,7 @@ if [[ $# -eq 0 ]]; then
     docker exec -it frappe bash
 elif [ "$1" == 'init' ]; then
     docker exec -itu root frappe bash -c "cd /home/frappe && chown -R frappe:frappe ./*"
-    docker exec -i frappe bash -c "cd .. && bench init $2 --ignore-exist --skip-redis-config-generation"
+    docker exec -i frappe bash -c "cd .. && bench init frappe-bench --ignore-exist --skip-redis-config-generation && cd frappe-bench"
     docker exec -i frappe bash -c "mv Procfile_docker Procfile && mv sites/common_site_config_docker.json sites/common_site_config.json && bench set-mariadb-host mariadb"
 elif [ "$1" == 'setup' ]; then
     if [ "$2" == 'docker' ]; then


### PR DESCRIPTION
`./dbench init` would lead to 'missing argument: PATH' issue (#54), and could not find Procfile_docker and site-config.

Signed-off-by: Chinmay Pai <chinmaydpai@gmail.com>