### PR TITLE
Clean cache in the same RUN to get a smaller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ ENV LANG C.UTF-8
 RUN apt-get update && apt-get install -y iputils-ping git build-essential python-setuptools python-dev libffi-dev libssl-dev libjpeg8-dev \
   redis-tools redis-server software-properties-common libxrender1 libxext6 xfonts-75dpi xfonts-base zlib1g-dev libfreetype6-dev \
   liblcms2-dev libwebp-dev python-tk apt-transport-https libsasl2-dev libldap2-dev libtiff5-dev tcl8.6-dev tk8.6-dev \
-  wget libmysqlclient-dev mariadb-client mariadb-common curl rlwrap redis-tools nano wkhtmltopdf python-pip vim sudo
-RUN pip install --upgrade setuptools pip
+  wget libmysqlclient-dev mariadb-client mariadb-common curl rlwrap redis-tools nano wkhtmltopdf python-pip vim sudo && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+RUN pip install --upgrade setuptools pip && rm -rf ~/.cache/pip
 RUN useradd -ms /bin/bash -G sudo frappe && printf '# User rules for frappe\nfrappe ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/frappe
 
 #nodejs
@@ -25,10 +26,9 @@ WORKDIR /home/frappe
 RUN git clone -b master https://github.com/frappe/bench.git bench-repo
 
 USER root
-RUN pip install -e bench-repo \
+RUN pip install -e bench-repo && rm -rf ~/.cache/pip \
   && npm install -g yarn \
-  && chown -R frappe:frappe /home/frappe/* \
-  && rm -rf /var/lib/apt/lists/*
+  && chown -R frappe:frappe /home/frappe/*
 
 USER frappe
 WORKDIR /home/frappe/frappe-bench


### PR DESCRIPTION
Please include this commit to decrease the size of the docker image, the "rm -rf /var/lib/apt/lists/*" it is not usefull if it is not used in the same stage of the apt-get install RUN, similar with pip cache.

References:
 - https://linux.die.net/man/8/apt-get
 - https://stackoverflow.com/questions/9510474/removing-pips-cache
 - https://semaphoreci.com/blog/2016/12/13/lightweight-docker-images-in-5-steps.html

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file;

(b) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

Signed-off-by: William Moreno Reyes <williamjmorenor@gmail.com>