### PR TITLE
Install Frappe using alpine image

### DIFF
--- a/Dockerfile-frappe-alpine
+++ b/Dockerfile-frappe-alpine
@@ -52,7 +52,11 @@ RUN cd /home/frappe \
 
 WORKDIR /home/frappe/frappe-bench
 
+VOLUME /home/frappe/frappe-bench/sites
+
 EXPOSE 8000
+EXPOSE 9000
+EXPOSE 6787
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["start"]

--- a/Dockerfile-frappe-alpine
+++ b/Dockerfile-frappe-alpine
@@ -1,0 +1,58 @@
+# Frappe Bench
+FROM alpine:latest
+MAINTAINER developers@frappe.io
+
+USER root
+ENV LANG C.UTF-8
+
+COPY docker-entrypoint.sh usr/local/bin/docker-entrypoint.sh
+RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+
+RUN apk add --update --no-cache \
+  build-base \
+  libffi-dev \
+  git \
+  su-exec \
+  nodejs \
+  yarn \
+  python-dev \
+  py-pip \
+  jpeg-dev \
+  zlib-dev \
+  libxslt-dev \
+  libxml2-dev \
+  postgresql-dev \
+  gcc \
+  python3-dev \
+  musl-dev \
+  mysql-client
+
+RUN pip install --upgrade setuptools pip && rm -rf ~/.cache/pip
+RUN mkdir -p /home/frappe && adduser -h /home/frappe -D frappe
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+RUN cd /tmp \
+  && wget -c https://github.com/frappe/wkhtmltopdf/raw/master/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz \
+  && tar xvf wkhtmltox-0.12.3_linux-generic-amd64.tar.xz \
+  && cp wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf \
+  && chmod o+x /usr/local/bin/wkhtmltopdf
+
+RUN git clone https://github.com/revant/bench.git /home/frappe/.bench -b docker \
+  && pip install -e /home/frappe/.bench \
+  && chown -R frappe:frappe /home/frappe
+
+USER frappe
+RUN cd /home/frappe \
+  && bench init frappe-bench --in-docker \
+  && cd frappe-bench
+
+WORKDIR /home/frappe/frappe-bench
+
+EXPOSE 8000
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["start"]

--- a/README.md
+++ b/README.md
@@ -122,6 +122,33 @@ To login to Frappe / ERPNext, open your browser and go to `[your-external-ip]:80
 
 The default username is "Administrator" and password is what you set when you created the new site. The default admin password is set in common_site_config.json, and is set to 'admin' in this docker image.
 
+## Dockerfile-frappe-alpine
+
+this file has docker entrypoint, following command works
+
+```
+docker run \
+    --network host \
+    -e DB_HOST=localhost \
+    -e DB_PASSWORD=$DB_PASSWORD \
+    -e ADMIN_PASSWORD=admin \
+    -e REDIS_QUEUE=localhost \
+    -e REDIS_SOCKETIO=localhost \
+    -e REDIS_CACHE=localhost \
+    -v /home/revant/tmp/frappesites:/home/frappe/frappe-bench/sites \
+    -it start
+
+```
+
+Commands internal to container are
+
+```
+new-site test_site1.localhost # creates new site on db/password mentioned via env vars.
+start # does bench start
+migrate test_site1.localhost # migrates the specified site
+
+```
+
 ## Built With
 
 * [Docker](https://www.docker.com/)

--- a/README.md
+++ b/README.md
@@ -135,8 +135,7 @@ docker run \
     -e REDIS_QUEUE=localhost \
     -e REDIS_SOCKETIO=localhost \
     -e REDIS_CACHE=localhost \
-    -v /home/revant/tmp/frappesites:/home/frappe/frappe-bench/sites \
-    -it start
+    -it frappe:alpine new-site test_site1.localhost
 
 ```
 

--- a/docker-compose-frappe-alpine.yml
+++ b/docker-compose-frappe-alpine.yml
@@ -1,0 +1,72 @@
+version: '2'
+services:
+  mariadb:
+    image: mariadb
+    environment:
+      - MYSQL_ROOT_PASSWORD=123
+      - MYSQL_USER=root
+    volumes:
+      - ./conf/mariadb-conf.d:/etc/mysql/conf.d
+      - /var/lib/mysql
+    ports:
+      - "3307:3306" #mariadb-port
+    container_name: mariadb
+
+  redis-cache:
+    image: redis:alpine
+
+    volumes:
+      - ./redis-conf:/etc/conf.d
+
+    command: ["redis-server","/etc/conf.d/redis_cache.conf"]
+
+    container_name: redis-cache
+
+  redis-queue:
+    image: redis:alpine
+
+    volumes:
+      - ./redis-conf:/etc/conf.d
+
+    command: ["redis-server","/etc/conf.d/redis_queue.conf"]
+
+    container_name: redis-queue
+
+  redis-socketio:
+    image: redis:alpine
+
+    volumes:
+      - ./redis-conf:/etc/conf.d
+
+    command: ["redis-server","/etc/conf.d/redis_socketio.conf"]
+
+    container_name: redis-socketio
+
+
+  frappe:
+    environment:
+      - DB_HOST=mariadb
+      - DB_PASSWORD=123
+      - ADMIN_PASSWORD=admin
+      - REDIS_QUEUE=redis-queue
+      - REDIS_SOCKETIO=redis-socketio
+      - REDIS_CACHE=redis-cache
+
+    image: frappe:alpine
+    ports:
+      - "8000:8000" #webserver_port
+      - "9000:9000" #socketio_port
+      - "6787:6787" #file_watcher_port
+    stdin_open: true
+    tty: true
+    links:
+      - redis-cache
+      - redis-queue
+      - redis-socketio
+      - mariadb
+    depends_on:
+      - mariadb
+      - redis-cache
+      - redis-queue
+      - redis-socketio
+    container_name: frappe

--- a/docker-compose-frappe-alpine.yml
+++ b/docker-compose-frappe-alpine.yml
@@ -7,7 +7,7 @@ services:
       - MYSQL_USER=root
     volumes:
       - ./conf/mariadb-conf.d:/etc/mysql/conf.d
-      - /var/lib/mysql
+      - /tmp/mysql-data:/var/lib/mysql
     ports:
       - "3307:3306" #mariadb-port
     container_name: mariadb

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+
+function checkEnv() {
+  if [[ -z "$DB_HOST" ]]; then
+    echo "DB_HOST is not set"
+    exit 1
+  fi
+  if [[ -z "$DB_PASSWORD" ]]; then
+    echo "DB_PASSWORD is not set"
+    exit 1
+  fi
+  if [[ -z "$ADMIN_PASSWORD" ]]; then
+    echo "ADMIN_PASSWORD is not set"
+    exit 1
+  fi
+  if [[ -z "$REDIS_QUEUE" ]]; then
+    echo "REDIS_QUEUE is not set"
+    exit 1
+  fi
+  if [[ -z "$REDIS_SOCKETIO" ]]; then
+    echo "REDIS_SOCKETIO is not set"
+    exit 1
+  fi
+  if [[ -z "$REDIS_CACHE" ]]; then
+    echo "REDIS_CACHE is not set"
+    exit 1
+  fi
+}
+
+function checkConnection() {
+  # Wait for mariadb
+  dockerize -wait tcp://$DB_HOST:3306 -timeout 30s
+
+  # Wait for all redis
+  dockerize -wait tcp://$REDIS_QUEUE:11000 -timeout 30s
+  dockerize -wait tcp://$REDIS_SOCKETIO:12000 -timeout 30s
+  dockerize -wait tcp://$REDIS_CACHE:13000 -timeout 30s
+}
+
+function configureBench() {
+  # set common config
+  bench config set-common-config -c db_host $DB_HOST
+  bench config set-common-config -c redis_queue "redis://$REDIS_QUEUE:11000"
+  bench config set-common-config -c redis_socketio "redis://$REDIS_SOCKETIO:12000"
+  bench config set-common-config -c redis_cache "redis://$REDIS_CACHE:13000"
+
+  # set procfile
+  rm Procfile
+  bench setup procfile
+  tail -n +4 Procfile > Procfile.1
+  mv Procfile.1 Procfile
+}
+
+if [ "$1" = 'new-site' ]; then
+  # Validate if DB_HOST is set.
+  checkEnv
+  # Validate DB Connection
+  checkConnection
+  # configure bench
+  configureBench
+
+  bench new-site --mariadb-root-password $DB_PASSWORD --admin-password $ADMIN_PASSWORD "$2"
+fi
+
+if [ "$1" = 'start' ]; then
+  # Validate if DB_HOST is set.
+  checkEnv
+  # Validate DB Connection
+  checkConnection
+  # configure bench
+  configureBench
+  
+  bench start
+fi
+
+if [ "$1" = 'migrate' ]; then
+  # Validate if DB_HOST is set.
+  checkEnv
+  # Validate DB Connection
+  checkConnection
+  # configure bench
+  configureBench
+
+  bench --site "$2" migrate
+fi
+
+exec "$@"


### PR DESCRIPTION
Conf Sprint 2018

#58 

This Dockerfile and docker-compose for frappe:alpine is complete.
It has exposed ports and volume /home/frappe/frappe-bench/sites for accessing 

For Continuous Delivery, following steps need to be done

 - the Dockerfile and docker-entrypoint.sh need to be part of root frappe repo
 - instead of cloning frappe into bench init, frappe needs to be copied
 - in case frappe is copied instead of `bench init` then the config and installation steps will be manually done in Dockerfile
