### PR TITLE
chore: install wkhtmltox correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update && apt-get install -y --no-install-suggests --no-install-reco
   && npm install -g yarn
 
 # Install wkhtmltox correctly
-RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
-RUN tar xvf wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
-RUN mv wkhtmltox/bin/wkhtmlto* /usr/bin/
-RUN ln -nfs /usr/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf
+RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz \
+  &&  tar xvf wkhtmltox-0.12.4_linux-generic-amd64.tar.xz \
+  &&  mv wkhtmltox/bin/wkhtmlto* /usr/bin/ \
+  && ln -nfs /usr/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf
 
 # Add frappe user and setup sudo
 RUN useradd -ms /bin/bash -G sudo frappe \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,18 @@ ENV LC_ALL=en_US.UTF-8
 
 # Install all neccesary packages
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-suggests --no-install-recommends \
-  build-essential cron curl git libffi-dev liblcms2-dev libldap2-dev libmariadbclient-dev libsasl2-dev libssl-dev libtiff5-dev \
+  build-essential cron curl git libffi-dev liblcms2-dev libldap2-dev libmariadbclient-dev libsasl2-dev libssl1.0-dev libtiff5-dev \
   libwebp-dev mariadb-client iputils-ping python-dev python-pip python-setuptools python-tk redis-tools rlwrap \
-  software-properties-common sudo tk8.6-dev vim xfonts-75dpi xfonts-base wget wkhtmltopdf \
+  software-properties-common sudo tk8.6-dev vim xfonts-75dpi xfonts-base wget wkhtmltopdf fonts-cantarell \
   && apt-get clean && rm -rf /var/lib/apt/lists/* \
   && curl https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/nodejs_10.10.0-1nodesource1_amd64.deb > node.deb \
   && dpkg -i node.deb \
   && rm node.deb \
   && npm install -g yarn
+
+# Install wkhtmltox correctly
+RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb
+RUN dpkg -i wkhtmltox_0.12.5-1.stretch_amd64.deb && rm wkhtmltox_0.12.5-1.stretch_amd64.deb
 
 # Add frappe user and setup sudo
 RUN groupadd -g 500 frappe \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,19 @@ ENV LANG C.UTF-8
 RUN apt-get update && apt-get install -y --no-install-suggests --no-install-recommends build-essential cron curl git iputils-ping libffi-dev \
   liblcms2-dev libldap2-dev libmariadbclient-dev libsasl2-dev libssl-dev libtiff5-dev libwebp-dev mariadb-client \
   python-dev python-pip python-setuptools python-tk redis-tools rlwrap software-properties-common sudo tk8.6-dev \
-  vim xfonts-75dpi xfonts-base wget wkhtmltopdf \
+  vim xfonts-75dpi xfonts-base wget \
   && apt-get clean && rm -rf /var/lib/apt/lists/* \
   && pip install --upgrade setuptools pip --no-cache \
   && curl https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/nodejs_10.10.0-1nodesource1_amd64.deb > node.deb \
   && dpkg -i node.deb \
   && rm node.deb \
   && npm install -g yarn
+
+# Install wkhtmltox correctly
+RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
+RUN tar xvf wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
+RUN mv wkhtmltox/bin/wkhtmlto* /usr/bin/
+RUN ln -nfs /usr/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf
 
 # Add frappe user and setup sudo
 RUN useradd -ms /bin/bash -G sudo frappe \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     volumes:
       - ./conf/mariadb-conf.d:/etc/mysql/conf.d
       - /var/lib/mysql
-        #      - ./db/var/lib/mysql for data persistence
     
     ports:
       - "3307:3306" # MariaDB Port

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     volumes:
       - ./conf/mariadb-conf.d:/etc/mysql/conf.d
       - /var/lib/mysql
+        #      - ./db/var/lib/mysql for data persistence
     
     ports:
       - "3307:3306" # MariaDB Port


### PR DESCRIPTION
This way wkhtmltox is working with patched qt, last version avaible for debian stretch, the 0.12.5-1 doesn't seem to be supported yet