### PR TITLE
Update frappe image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Frappe Bench Dockerfile
 
-FROM debian:9.6-slim
+FROM debian:buster-slim
 LABEL author=frappé
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends locales \
@@ -14,20 +14,20 @@ ENV LANGUAGE=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
-# Install all neccesary packages
+# Install all neccesary packages (note: python-minimal is required by nodejs, less is needed by MariaDB monitor)
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-suggests --no-install-recommends \
-  build-essential cron curl git libffi-dev liblcms2-dev libldap2-dev libmariadbclient-dev libsasl2-dev libssl1.0-dev libtiff5-dev \
-  libwebp-dev mariadb-client iputils-ping python-dev python-pip python-setuptools python-tk redis-tools rlwrap \
+  build-essential cron curl git less libffi-dev liblcms2-dev libldap2-dev libmariadbclient-dev libsasl2-dev libssl-dev libtiff5-dev \
+  libwebp-dev mariadb-client iputils-ping python-minimal python3-dev python3-pip python3-setuptools python3-tk redis-tools rlwrap \
   software-properties-common sudo tk8.6-dev vim xfonts-75dpi xfonts-base wget wkhtmltopdf fonts-cantarell \
   && apt-get clean && rm -rf /var/lib/apt/lists/* \
-  && curl https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/nodejs_10.10.0-1nodesource1_amd64.deb > node.deb \
+  && curl https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/nodejs_12.16.1-1nodesource1_amd64.deb > node.deb \
   && dpkg -i node.deb \
   && rm node.deb \
   && npm install -g yarn
 
 # Install wkhtmltox correctly
-RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb
-RUN dpkg -i wkhtmltox_0.12.5-1.stretch_amd64.deb && rm wkhtmltox_0.12.5-1.stretch_amd64.deb
+RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.buster_amd64.deb
+RUN dpkg -i wkhtmltox_0.12.5-1.buster_amd64.deb && rm wkhtmltox_0.12.5-1.buster_amd64.deb
 
 # Add frappe user and setup sudo
 RUN groupadd -g 500 frappe \
@@ -36,7 +36,7 @@ RUN groupadd -g 500 frappe \
   && chown -R 500:500 /home/frappe
 
 # Install bench
-RUN pip install -e git+https://github.com/frappe/bench.git#egg=bench --no-cache
+RUN pip3 install -e git+https://github.com/frappe/bench.git#egg=bench --no-cache
 
 USER frappe
 


### PR DESCRIPTION
1. Update base image to `debian:buster-slim`, which updates Python to 3.7 as well
2. Update Node.js to 12.16.1