### PR TITLE
Update debian

### DIFF
--- a/build/bench/Dockerfile
+++ b/build/bench/Dockerfile
@@ -77,9 +77,7 @@ RUN echo '. "$NVM_DIR/nvm.sh"' >> /home/frappe/.bashrc
 RUN pip3 install -e git+https://github.com/frappe/bench.git#egg=bench --no-cache
 
 USER frappe
-
 WORKDIR /home/frappe/frappe-bench
-
 EXPOSE 8000 9000 6787
 
 VOLUME [ "/home/frappe/frappe-bench" ]

--- a/build/bench/Dockerfile
+++ b/build/bench/Dockerfile
@@ -53,8 +53,9 @@ RUN install_packages \
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb
 RUN dpkg -i wkhtmltox_0.12.5-1.stretch_amd64.deb && rm wkhtmltox_0.12.5-1.stretch_amd64.deb
 
-# Create new user with directory, add user to sudo group, allow passwordless sudo, switch to that user and change directory to user home directory
-RUN useradd --no-log-init -r -m -g  sudo frappe
+# Create new user with home directory, improve docker compatibility with UID/GID 1000, add user to sudo group, allow passwordless sudo, switch to that user and change directory to user home directory
+RUN groupadd -g 1000 frappe
+RUN useradd --no-log-init -r -m -u 1000 -g 1000 -G  sudo frappe
 RUN echo "frappe ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 USER frappe
 WORKDIR /home/frappe

--- a/build/bench/Dockerfile
+++ b/build/bench/Dockerfile
@@ -2,8 +2,6 @@
 FROM bitnami/minideb:latest
 LABEL author=frappé
 
-
-WORKDIR /home/frappe/frappe-bench
 RUN install_packages \
     git \
     wkhtmltopdf \
@@ -41,43 +39,73 @@ RUN install_packages \
     fonts-cantarell \
     # VSCode container requirements
     net-tools \
-# PYTHON
+    # PYTHON
     python3-dev \
     python3-pip \
     python3-setuptools \
-    python3-tk
-
+    python3-tk \
+    python-virtualenv
 
 # Install wkhtmltox correctly
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb
 RUN dpkg -i wkhtmltox_0.12.5-1.stretch_amd64.deb && rm wkhtmltox_0.12.5-1.stretch_amd64.deb
 
+# Create new user with directory, add user to sudo group, allow passwordless sudo, switch to that user and change directory to user home directory
+RUN useradd --no-log-init -r -m -g  sudo frappe
+RUN echo "frappe ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+USER frappe
+WORKDIR /home/frappe
 
+# Install bench in the local user home directory
+RUN pip3 install --user  git+https://github.com/frappe/bench.git#egg=bench --no-cache
 
-# Add frappe user and setup sudo
-RUN groupadd -g 1000 frappe \
-  && useradd -ms /bin/bash -u 1000 -g 1000 -G sudo frappe \
-  && chown -R 1000:1000 /home/frappe
+# Export python executables for Dockerfile
+ENV PATH=/home/frappe/.local/bin/:$PATH
+# Export python executables for interactive shell
+RUN echo "export PATH=/home/frappe/.local/bin/:\$PATH" >> /home/frappe/.bashrc
+
+# Print version and verify bashrc is properly sourced so that everything works in the Dockerfile
+RUN bench --version
+# Print version and verify bashrc is properly sourced so that everything works in the interactive shell
+RUN bash -c "bench --version"
+
 
 # Install nvm with node
-ENV NODE_VERSION=13.10.1
-RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
-ENV NVM_DIR=/root/.nvm
+# !!! UPDATE PERIODICALLY WITH LATEST VERSIONS !!!
+# https://nodejs.org/en/about/releases/
+# https://nodejs.org/download/release/latest-v10.x/
+# https://nodejs.org/download/release/latest-v12.x/
+# https://nodejs.org/download/release/latest-v13.x/
+
+ENV NODE_VERSION=12.16.1
+ENV NODE_VERSION_FRAPPEV11=10.19.0
+
+RUN wget https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh
+RUN chmod +x install.sh
+RUN ./install.sh
+
+ENV NVM_DIR=/home/frappe/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION_FRAPPEV11}
 RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
-ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+# Add NVM path for user in Dockerfile, interactive shell is already managed by the NVM install script
+ENV PATH="/home/frappe/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+
+# Install yarn
+RUN npm install -g yarn
+
+# Print version and verify bashrc is properly sourced so that everything works in the Dockerfile
 RUN node --version
 RUN npm --version
-RUN npm install -g yarn
 RUN yarn --version
-RUN echo '. "$NVM_DIR/nvm.sh"' >> /home/frappe/.bashrc
+# Print version and verify bashrc is properly sourced so that everything works in the interactive shell
+RUN bash -c "node --version"
+RUN bash -c "npm --version"
+RUN bash -c "yarn --version"
 
-# Install bench
-RUN pip3 install -e git+https://github.com/frappe/bench.git#egg=bench --no-cache
 
-USER frappe
 WORKDIR /home/frappe/frappe-bench
 EXPOSE 8000 9000 6787
 
-VOLUME [ "/home/frappe/frappe-bench" ]
+VOLUME [ "/root/frappe-bench" ]

--- a/build/bench/Dockerfile
+++ b/build/bench/Dockerfile
@@ -108,5 +108,3 @@ RUN bash -c "node --version" \
 
 WORKDIR /home/frappe/frappe-bench
 EXPOSE 8000 9000 6787
-
-VOLUME [ "/root/frappe-bench" ]

--- a/build/bench/Dockerfile
+++ b/build/bench/Dockerfile
@@ -21,6 +21,9 @@ RUN install_packages \
     vim \
     sudo \
     iputils-ping \
+    watch \
+    tree \
+    nano \
     software-properties-common \
     # For psycopg2
     libpq-dev \

--- a/build/bench/Dockerfile
+++ b/build/bench/Dockerfile
@@ -1,51 +1,77 @@
 # Frappe Bench Dockerfile
-
-FROM debian:9.6-slim
+FROM bitnami/minideb:latest
 LABEL author=frappé
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends locales \
-  && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
-  && dpkg-reconfigure --frontend=noninteractive locales \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Set locale en_us.UTF-8 for mariadb and general locale data
-ENV PYTHONIOENCODING=utf-8
-ENV LANGUAGE=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV LC_ALL=en_US.UTF-8
+WORKDIR /home/frappe/frappe-bench
+RUN install_packages \
+    git \
+    wkhtmltopdf \
+    mariadb-client \
+    gettext-base \
+    wget \
+    # for PDF
+    libssl-dev \
+    fonts-cantarell \
+    xfonts-75dpi \
+    xfonts-base \
+    # to work inside the container
+    locales \
+    build-essential \
+    cron \
+    curl \
+    vim \
+    sudo \
+    iputils-ping \
+    software-properties-common \
+    # For psycopg2
+    libpq-dev \
+    build-essential \ 
+    # Other
+    libffi-dev \
+    liblcms2-dev \
+    libldap2-dev \
+    libmariadbclient-dev \
+    libsasl2-dev \
+    libtiff5-dev \
+    libwebp-dev \
+    redis-tools \
+    rlwrap \
+    tk8.6-dev \
+    fonts-cantarell \
+    # VSCode container requirements
+    net-tools \
+# PYTHON
+    python3-dev \
+    python3-pip \
+    python3-setuptools \
+    python3-tk
 
-# Install all neccesary packages
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-suggests --no-install-recommends \
-  build-essential cron curl git libffi-dev liblcms2-dev libldap2-dev libmariadbclient-dev libsasl2-dev libssl1.0-dev libtiff5-dev \
-  libwebp-dev mariadb-client iputils-ping python3-dev python3-pip python3-setuptools python3-tk redis-tools rlwrap \
-  software-properties-common sudo tk8.6-dev vim xfonts-75dpi xfonts-base wget wkhtmltopdf fonts-cantarell net-tools \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Add frappe user and setup sudo
-RUN groupadd -g 1000 frappe \
-  && useradd -ms /bin/bash -u 1000 -g 1000 -G sudo frappe \
-  && chown -R 1000:1000 /home/frappe \
-  && echo '. "$NVM_DIR/nvm.sh"' >> /home/frappe/.bashrc
-
-# Install nvm with node
-ENV NVM_DIR /home/frappe/.nvm
-ENV NODE_VERSION 12.16.1
-RUN mkdir /home/frappe/.nvm \
-    && wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.35.2/install.sh | bash \
-    && . $NVM_DIR/nvm.sh \
-    && nvm install $NODE_VERSION \
-    && nvm install 10.19.0 \
-    && npm install yarn -g \
-    && nvm alias default $NODE_VERSION \
-    && nvm use default \
-    && npm install yarn -g \
-    && chown -R frappe:frappe /home/frappe
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 # Install wkhtmltox correctly
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb
 RUN dpkg -i wkhtmltox_0.12.5-1.stretch_amd64.deb && rm wkhtmltox_0.12.5-1.stretch_amd64.deb
+
+
+
+# Add frappe user and setup sudo
+RUN groupadd -g 1000 frappe \
+  && useradd -ms /bin/bash -u 1000 -g 1000 -G sudo frappe \
+  && chown -R 1000:1000 /home/frappe
+
+# Install nvm with node
+ENV NODE_VERSION=13.10.1
+RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
+ENV NVM_DIR=/root/.nvm
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
+ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+RUN node --version
+RUN npm --version
+RUN npm install -g yarn
+RUN yarn --version
+RUN echo '. "$NVM_DIR/nvm.sh"' >> /home/frappe/.bashrc
 
 # Install bench
 RUN pip3 install -e git+https://github.com/frappe/bench.git#egg=bench --no-cache

--- a/build/bench/Dockerfile
+++ b/build/bench/Dockerfile
@@ -85,13 +85,15 @@ ENV NODE_VERSION_FRAPPEV11=10.19.0
 RUN wget https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh
 RUN chmod +x install.sh
 RUN ./install.sh
-
 ENV NVM_DIR=/home/frappe/.nvm
-RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+
+# Install node for Frappe V11, install yarn
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION_FRAPPEV11}
-RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION_FRAPPEV11} && npm install -g yarn 
+# Install node for latest frappe, set as default, install node
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}  && npm install -g yarn 
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
-# Add NVM path for user in Dockerfile, interactive shell is already managed by the NVM install script
 ENV PATH="/home/frappe/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
 # Install yarn

--- a/build/bench/Dockerfile
+++ b/build/bench/Dockerfile
@@ -72,17 +72,15 @@ RUN bench --version
 # Print version and verify bashrc is properly sourced so that everything works in the interactive shell
 RUN bash -c "bench --version"
 
-
-# Install nvm with node
-# !!! UPDATE PERIODICALLY WITH LATEST VERSIONS !!!
+# !!! UPDATE NODEJS PERIODICALLY WITH LATEST VERSIONS !!!
 # https://nodejs.org/en/about/releases/
 # https://nodejs.org/download/release/latest-v10.x/
 # https://nodejs.org/download/release/latest-v12.x/
 # https://nodejs.org/download/release/latest-v13.x/
-
 ENV NODE_VERSION=12.16.1
 ENV NODE_VERSION_FRAPPEV11=10.19.0
 
+# Install nvm with node
 RUN wget https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh
 RUN chmod +x install.sh
 RUN ./install.sh
@@ -99,13 +97,13 @@ ENV PATH="/home/frappe/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 RUN npm install -g yarn
 
 # Print version and verify bashrc is properly sourced so that everything works in the Dockerfile
-RUN node --version
-RUN npm --version
-RUN yarn --version
+RUN node --version \
+    && npm --version \ 
+    && yarn --version
 # Print version and verify bashrc is properly sourced so that everything works in the interactive shell
-RUN bash -c "node --version"
-RUN bash -c "npm --version"
-RUN bash -c "yarn --version"
+RUN bash -c "node --version" \
+    && bash -c "npm --version" \
+    && bash -c "yarn --version"
 
 
 WORKDIR /home/frappe/frappe-bench


### PR DESCRIPTION
Fixes #123 
Partially addresses #134 

So as you can see from the changenote I've:

- Moved the image from debian to the same minideb used by the bitnami images
- Used the install_packages script from bitnami
- Moved python and nvm/node to the frappe user

I'd recommend testing manually