### PR TITLE
Develop

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,12 @@
   "workspaceFolder": "/workspace/development",
 "shutdownAction": "stopCompose",
 "extensions": [
-	"ms-python.python"
+	"ms-python.python",
+	"auchenberg.vscode-browser-preview",
+	"grapecity.gc-excelviewer",
+	"mtxr.sqltools",
+	"visualstudioexptteam.vscodeintellicode",
+	"yzhang.markdown-all-in-one",
+	"bierner.markdown-emoji"
 ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,8 +14,6 @@
 	"auchenberg.vscode-browser-preview",
 	"grapecity.gc-excelviewer",
 	"mtxr.sqltools",
-	"visualstudioexptteam.vscodeintellicode",
-	"yzhang.markdown-all-in-one",
-	"bierner.markdown-emoji"
+	"visualstudioexptteam.vscodeintellicode"
 ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,8 +4,7 @@
 
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
-		"ms-vscode-remote.remote-containers",
-		"ms-python.python"
+		"ms-vscode-remote.remote-containers"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [

--- a/development/README.md
+++ b/development/README.md
@@ -85,7 +85,6 @@ sed -i '/redis/d' ./Procfile
 
 ### Create a new site with bench
 
-Your installation already includes a site for [localhost](http://locahost:8000)
 You can create a new site with the following command:
 
 ```shell
@@ -98,6 +97,12 @@ for example:
 bench new-site mysite.localhost
 ```
 
+The same command can be run non-interactively as well:
+
+```shell
+bench new-site mysite.localhost --mariadb-root-password 123 --admin-password admin
+```
+
 The command will ask the MariaDB root password. The default root password is `123`.
 This will create a new site and a `mysite.localhost` directory under `frappe-bench/sites`.
 You may need to configure your system /etc/hosts if you're on Linux, Mac, or its Windows equivalent.
@@ -107,8 +112,8 @@ You may need to configure your system /etc/hosts if you're on Linux, Mac, or its
 To develop a new app, the last step will be setting the site into developer mode. Documentation is available at [this link](https://frappe.io/docs/user/en/guides/app-development/how-enable-developer-mode-in-frappe).
 
 ```shell
-bench --site my.site set-config developer_mode 1
-bench --site my.site clear-cache
+bench --site mysite.localhost set-config developer_mode 1
+bench --site mysite.localhost clear-cache
 ```
 
 ### Install an app
@@ -119,8 +124,16 @@ You can check [VSCode container remote extension documentation](https://code.vis
 
 ```shell
 bench get-app myapp https://github.com/myusername/myapp.git
-bench --site my.site install-app myapp
+bench --site mysite.localhost install-app myapp
 ```
+
+For example, to install ERPNext (from the master branch):
+
+```shell
+bench get-app erpnext https://github.com/frappe/erpnext.git
+bench --site mysite.localhost install-app erpnext
+```
+
 
 ### Start Frappe without debugging
 
@@ -133,52 +146,6 @@ bench start
 You can now login with user `Administrator` and the password you choose when creating the site.
 Your website will now be accessible on [on port 8000](http://locahost:8000)
 Note: To start bench with debugger refer section for debugging.
-
-### Fixing MariaDB issues after rebuilding the container
-
-The `bench new-site` command creates a user in MariaDB with container IP as host, for this reason after rebuilding the container there is a chance that you will not be able to access MariaDB correctly with the previous configuration
-The parameter `'db_name'@'%'` needs to be set in MariaDB and permission to the site database suitably assigned to the user.
-
-This step has to be repeated for all sites available under the current bench.
-Example shows the queries to be executed for site `localhost`
-
-Open sites/localhost/site_config.json:
-
-
-```shell
-code sites/localhost/site_config.json
-```
-
-and take note of the parameters `db_name` and `db_password`.
-
-Enter MariaDB Interactive shell:
-
-```shell
-mysql -uroot -p123 -hmariadb
-```
-
-Execute following queries replacing `db_name` and `db_password` with the values found in site_config.json.
-
-```sql
-UPDATE mysql.user SET Host = '%' where User = 'db_name'; FLUSH PRIVILEGES;
-SET PASSWORD FOR 'db_name'@'%' = PASSWORD('db_password'); FLUSH PRIVILEGES;
-GRANT ALL PRIVILEGES ON `db_name`.* TO 'db_name'@'%'; FLUSH PRIVILEGES;
-EXIT;
-```
-
-## Manually start containers
-
-In case you don't use VSCode, you may start the containers manually with the following command:
-
-```shell
-docker-compose -f .devcontainer/docker-compose.yml up -d
-```
-
-And enter the interactive shell for the development container with the following command:
-
-```shell
-docker exec -e "TERM=xterm-256color" -w /workspace/development -it devcontainer_frappe_1 bash
-```
 
 ### Start Frappe with Visual Studio Code Python Debugging
 
@@ -227,4 +194,50 @@ frappe.init(site='my.site', sites_path='/workspace/development/frappe-bench/site
 frappe.connect()
 frappe.local.lang = frappe.db.get_default('lang')
 frappe.db.connect()
+```
+
+### Fixing MariaDB issues after rebuilding the container
+
+The `bench new-site` command creates a user in MariaDB with container IP as host, for this reason after rebuilding the container there is a chance that you will not be able to access MariaDB correctly with the previous configuration
+The parameter `'db_name'@'%'` needs to be set in MariaDB and permission to the site database suitably assigned to the user.
+
+This step has to be repeated for all sites available under the current bench.
+Example shows the queries to be executed for site `localhost`
+
+Open sites/localhost/site_config.json:
+
+
+```shell
+code sites/localhost/site_config.json
+```
+
+and take note of the parameters `db_name` and `db_password`.
+
+Enter MariaDB Interactive shell:
+
+```shell
+mysql -uroot -p123 -hmariadb
+```
+
+Execute following queries replacing `db_name` and `db_password` with the values found in site_config.json.
+
+```sql
+UPDATE mysql.user SET Host = '%' where User = 'db_name'; FLUSH PRIVILEGES;
+SET PASSWORD FOR 'db_name'@'%' = PASSWORD('db_password'); FLUSH PRIVILEGES;
+GRANT ALL PRIVILEGES ON `db_name`.* TO 'db_name'@'%'; FLUSH PRIVILEGES;
+EXIT;
+```
+
+## Manually start containers
+
+In case you don't use VSCode, you may start the containers manually with the following command:
+
+```shell
+docker-compose -f .devcontainer/docker-compose.yml up -d
+```
+
+And enter the interactive shell for the development container with the following command:
+
+```shell
+docker exec -e "TERM=xterm-256color" -w /workspace/development -it devcontainer_frappe_1 bash
 ```

--- a/development/README.md
+++ b/development/README.md
@@ -173,7 +173,7 @@ You can now login with user `Administrator` and the password you choose when cre
 You can launch a simple interactive shell console in the terminal with:
 
 ```shell
-ench --site mysite.localhost console
+bench --site mysite.localhost console
 ```
 
 More likely, you may want to launch VSCode interactive console based on Jupyter kernel. 

--- a/development/README.md
+++ b/development/README.md
@@ -149,7 +149,7 @@ Note: To start bench with debugger refer section for debugging.
 
 ### Start Frappe with Visual Studio Code Python Debugging
 
-To enable Python debugging inside Visual Studio Code, you must first install the `ms-python.python` extension inside the container.
+To enable Python debugging inside Visual Studio Code, you must first install the `ms-python.python` extension inside the container. This should have already happened automatically, but depending on your VSCode config, you can force it by:
 
 - Click on the extension icon inside VSCode
 - Search `ms-python.python`
@@ -170,7 +170,7 @@ honcho start \
 
 This command starts all processes with the exception of Redis (which is already running in separate container) and the `web` process. The latter can can finally be started from the debugger tab of VSCode by clicking on the "play" button.
 
-You can now login with user `Administrator` and the password you choose when creating the site.
+You can now login with user `Administrator` and the password you choose when creating the site, if you followed this guide's unattended install that password is going to be `admin`.
 
 ## Developing using the interactive console
 
@@ -180,21 +180,29 @@ You can launch a simple interactive shell console in the terminal with:
 bench console
 ```
 
-More likely, you may want to launch VSCoode interactive console based on Jupyter kernel. 
+More likely, you may want to launch VSCode interactive console based on Jupyter kernel. 
+
+First of all, we need to install Jupyter in the correct environment, which can be done with the following command:
+
+```shell
+/workspace/development/frappe-bench/env/bin/python -m pip install jupyter ipykernel
+```
 
 Launch VSCode command palette (cmd+shift+p or ctrl+shift+p), run the command `Python: Select interpreter to start Jupyter server` and select `/workspace/development/frappe-bench/env/bin/python`.
 
 Then, run the commmand `Python: Show Python interactive window` from the VSCode command palette.
 
-Replace `my.site` with your site and run the following code in a Jupyter cell:
+Replace `mysite.localhost` with your site and run the following code in a Jupyter cell:
 
 ```python 
 import frappe
-frappe.init(site='my.site', sites_path='/workspace/development/frappe-bench/sites')
+frappe.init(site='mysite.localhost', sites_path='/workspace/development/frappe-bench/sites')
 frappe.connect()
 frappe.local.lang = frappe.db.get_default('lang')
 frappe.db.connect()
 ```
+
+The first command can take a few seconds to be executed, this is to be expected.
 
 ### Fixing MariaDB issues after rebuilding the container
 

--- a/development/README.md
+++ b/development/README.md
@@ -32,10 +32,6 @@ VSCode should automatically inquiry you to install the required extensions, that
     - through command line `code --install-extension ms-vscode-remote.remote-containers`
     - clicking on the button at the following link: [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
     - searching for extension `ms-vscode-remote.remote-containers`
-- Install Python for VSCode
-    - through command line `code --install-extension ms-python.python`
-    - clicking on the button at the following link: [install](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
-    - searching for extension `ms-python.python`
 
 After the extensions are installed, you can:
 
@@ -177,18 +173,18 @@ You can now login with user `Administrator` and the password you choose when cre
 You can launch a simple interactive shell console in the terminal with:
 
 ```shell
-bench console
+ench --site mysite.localhost console
 ```
 
 More likely, you may want to launch VSCode interactive console based on Jupyter kernel. 
 
-First of all, we need to install Jupyter in the correct environment, which can be done with the following command:
+Launch VSCode command palette (cmd+shift+p or ctrl+shift+p), run the command `Python: Select interpreter to start Jupyter server` and select `/workspace/development/frappe-bench/env/bin/python`.
+
+The first step is installing and updating the required software. Usually the frappe framework may require an older version of Jupyter, while VSCode likes to move fast, this can [cause issues](https://github.com/jupyter/jupyter_console/issues/158). For this reason we need to run the following command.
 
 ```shell
-/workspace/development/frappe-bench/env/bin/python -m pip install jupyter ipykernel
+/workspace/development/frappe-bench/env/bin/python -m pip install --upgrade jupyter ipykernel ipython
 ```
-
-Launch VSCode command palette (cmd+shift+p or ctrl+shift+p), run the command `Python: Select interpreter to start Jupyter server` and select `/workspace/development/frappe-bench/env/bin/python`.
 
 Then, run the commmand `Python: Show Python interactive window` from the VSCode command palette.
 


### PR DESCRIPTION
Following improvements to the development environment:
- python vscode extension has been removed from the requirements outside of the container as was not needed
- added some useful extensions by default that provide a common ground to develop tutorials and video tutorials around the frappe framework: sqltools, gc-excelviewer, vscode-browser-preview
- added intellicode extension by default
- improved documentation 
- fixed procedure for Jupyter notebooks inside vscode