### PR TITLE
fix(frappe-nginx): Generate Standard Style CSS

### DIFF
--- a/build/frappe-nginx/Dockerfile
+++ b/build/frappe-nginx/Dockerfile
@@ -6,13 +6,23 @@ RUN mkdir -p /home/frappe/frappe-bench/sites \
 
 RUN install_packages git
 
-RUN mkdir -p apps sites/assets  \
+RUN mkdir -p apps sites/assets/css  \
     && cd apps \
     && git clone --depth 1 https://github.com/frappe/frappe
+
+COPY build/frappe-nginx/generate_standard_style_css.js \
+    /home/frappe/frappe-bench/apps/frappe/generate_standard_style_css.js
 
 RUN cd /home/frappe/frappe-bench/apps/frappe \
     && yarn \
     && yarn run production \
+    && yarn add nunjucks -D \
+    && node generate_standard_style_css.js \
+        frappe/website/doctype/website_theme/website_theme_template.scss > \
+        /home/frappe/standard_templates_string \
+    && node generate_bootstrap_theme.js \
+        /home/frappe/frappe-bench/sites/assets/css/standard_style.css \
+        "$(cat /home/frappe/standard_templates_string)" \
     && rm -fr node_modules \
     && yarn install --production=true \
     && node --version \

--- a/build/frappe-nginx/generate_standard_style_css.js
+++ b/build/frappe-nginx/generate_standard_style_css.js
@@ -1,0 +1,14 @@
+const nunjucks = require("nunjucks");
+
+const templatePath = process.argv[2];
+const pathArray = templatePath.split("/");
+const templateFile = pathArray.pop();
+const templateDir = pathArray.join("/");
+
+nunjucks.configure(templateDir);
+const rendered = nunjucks.render(templateFile, {
+    button_rounded_corners: true,
+    font_properties: "300,600",
+});
+
+console.log(rendered.replace(/\n/gm, "\\n"));

--- a/build/frappe-nginx/v12.Dockerfile
+++ b/build/frappe-nginx/v12.Dockerfile
@@ -6,13 +6,23 @@ RUN mkdir -p /home/frappe/frappe-bench/sites \
 
 RUN install_packages git
 
-RUN mkdir -p apps sites/assets  \
+RUN mkdir -p apps sites/assets/css  \
     && cd apps \
     && git clone --depth 1 https://github.com/frappe/frappe --branch version-12
+
+COPY build/frappe-nginx/generate_standard_style_css.js \
+    /home/frappe/frappe-bench/apps/frappe/generate_standard_style_css.js
 
 RUN cd /home/frappe/frappe-bench/apps/frappe \
     && yarn \
     && yarn run production \
+    && yarn add nunjucks -D \
+    && node generate_standard_style_css.js \
+        frappe/website/doctype/website_theme/website_theme_template.scss > \
+        /home/frappe/standard_templates_string \
+    && node generate_bootstrap_theme.js \
+        /home/frappe/frappe-bench/sites/assets/css/standard_style.css \
+        "$(cat /home/frappe/standard_templates_string)" \
     && rm -fr node_modules \
     && yarn install --production=true \
     && node --version \


### PR DESCRIPTION
use nunjucks to render jinja2 template
generate default theme
Indicator not working.
Login, Invalid Login and Success Indicator CSS not working
Indicator also not working in non-docker style (problem with core code)