### PR TITLE
revert(frappe-nginx): revert v12.Dockerfile

### DIFF
--- a/build/frappe-nginx/v12.Dockerfile
+++ b/build/frappe-nginx/v12.Dockerfile
@@ -6,23 +6,13 @@ RUN mkdir -p /home/frappe/frappe-bench/sites \
 
 RUN install_packages git
 
-RUN mkdir -p apps sites/assets/css  \
+RUN mkdir -p apps sites/assets  \
     && cd apps \
     && git clone --depth 1 https://github.com/frappe/frappe --branch version-12
-
-COPY build/frappe-nginx/generate_standard_style_css.js \
-    /home/frappe/frappe-bench/apps/frappe/generate_standard_style_css.js
 
 RUN cd /home/frappe/frappe-bench/apps/frappe \
     && yarn \
     && yarn run production \
-    && yarn add nunjucks -D \
-    && node generate_standard_style_css.js \
-        frappe/website/doctype/website_theme/website_theme_template.scss > \
-        /home/frappe/standard_templates_string \
-    && node generate_bootstrap_theme.js \
-        /home/frappe/frappe-bench/sites/assets/css/standard_style.css \
-        "$(cat /home/frappe/standard_templates_string)" \
     && rm -fr node_modules \
     && yarn install --production=true \
     && node --version \


### PR DESCRIPTION
standard_style.css generation not required for v12

`frappe/website/doctype/website_theme/website_theme_template.scss` doesn't exist in version-12