### PR TITLE
fix: restore backup grant privileges command

### DIFF
--- a/build/common/commands/restore_backup.py
+++ b/build/common/commands/restore_backup.py
@@ -78,16 +78,10 @@ def restore_database(files_base, site):
     )
     os.system(create_user)
 
-    # create user password
-    set_user_password = mysql_command + "\"ALTER USER '{db_name}'@'%' IDENTIFIED BY '{db_password}'; FLUSH PRIVILEGES;\"".format(
+    # grant db privileges to user
+    grant_privileges = mysql_command + "\"GRANT ALL PRIVILEGES ON \`{db_name}\`.* TO '{db_name}'@'%' IDENTIFIED BY '{db_password}'; FLUSH PRIVILEGES;\"".format(
         db_name=site_config.get('db_name'),
         db_password=site_config.get('db_password')
-    )
-    os.system(set_user_password)
-
-    # grant db privileges to user
-    grant_privileges = mysql_command + "\"GRANT ALL PRIVILEGES ON \`{db_name}\`.* TO '{db_name}'@'%'; FLUSH PRIVILEGES;\"".format(
-        db_name=site_config.get('db_name')
     )
     os.system(grant_privileges)
 


### PR DESCRIPTION
ALTER USER fails if user does not exists.
Create/Alter user and grant privileges.