### PR TITLE
Fix socketio error in reverse proxy setup

### DIFF
--- a/build/common/nginx-default.conf.template
+++ b/build/common/nginx-default.conf.template
@@ -30,7 +30,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header X-Frappe-Site-Name $host;
-        proxy_set_header Origin $scheme://$http_host;
+        proxy_set_header Origin $http_referer;
         proxy_set_header Host $http_host;
 
         proxy_pass http://socketio-server;


### PR DESCRIPTION
Trying to fix #231 with setting the Header `origin` to `$http_referer`.

`$http_referer` seems to hold the URL which the request comes from  (e.g. http://erp.example.com) 

Socketio extracts the value from the `origin` header (see here: https://github.com/frappe/frappe/blob/253109e2f9413c5e5851f50ebd54260b0623fbf7/socketio.js#L288)

In my case it fixes the problem but I'm not sure, if it affects something else...