### PR TITLE
Set /workspace/development as default working dir

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     command: sleep infinity
     volumes:
       - ..:/workspace:cached
+    working_dir: /workspace/development
     ports:
       - "8000:8000"
       - "9000:9000"


### PR DESCRIPTION
When one misses the part of the doc that says bench should be created under /workspace/development, bench is created in home directory and the work would be lost when the container is recreated. Making the directory default would avert that

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
