### PR TITLE
Multibench support in devel environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM frappe/bench:latest
+EXPOSE 8000-8005 9000-9005 6787

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,14 +19,14 @@ services:
     image: redis:alpine
 
   frappe:
-    image: frappe/bench:latest
+    build: .
     command: sleep infinity
     volumes:
       - ..:/workspace:cached
     working_dir: /workspace/development
     ports:
-      - "8000:8000"
-      - "9000:9000"
+      - "8000-8005:8000-8005"
+      - "9000-9005:9000-9005"
 
 volumes:
   mariadb-vol:

--- a/development/README.md
+++ b/development/README.md
@@ -243,7 +243,10 @@ EXIT;
 ## Manually start containers
 
 In case you don't use VSCode, you may start the containers manually with the following command:
-
+```shell
+cd .devcontainer
+docker-compose build
+```
 ```shell
 docker-compose -f .devcontainer/docker-compose.yml up -d
 ```

--- a/development/README.md
+++ b/development/README.md
@@ -243,10 +243,15 @@ EXIT;
 ## Manually start containers
 
 In case you don't use VSCode, you may start the containers manually with the following command:
+
+### Building the containers
 ```shell
 cd .devcontainer
 docker-compose build
+cd ..
 ```
+
+### Running the containers
 ```shell
 docker-compose -f .devcontainer/docker-compose.yml up -d
 ```


### PR DESCRIPTION
The current development container only exposes ports 8000 and 9000. It is not possible to have multiple bench since each bench needs a port. A Dockerfile was added to development to expose 5 ports (8000 to 8005 and 9000 to 9005). 

docker-compose was also updated accordingly