### PR TITLE
Doc additions and minor fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
 
   site-creator:
     image: frappe/erpnext-worker:${ERPNEXT_VERSION}
-    restart: no
+    restart: "no"
     command: new
     depends_on:
       - erpnext-python

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,15 @@ services:
       - "--certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web"
       - "--certificatesresolvers.myresolver.acme.email=${LETSENCRYPT_EMAIL}"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+    labels:
+      # enable traefik
+      - "traefik.enable=true"
+      # global redirect to https for production only
+      - "${HTTPS_REDIRECT_RULE_LABEL}"
+      - "${HTTPS_REDIRECT_ENTRYPOINT_LABEL}"
+      - "${HTTPS_REDIRECT_MIDDLEWARE_LABEL}"
+      # middleware redirect for production only
+      - "${HTTPS_USE_REDIRECT_MIDDLEWARE_LABEL}"
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - "cert-vol:/letsencrypt"
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - cert-vol:/letsencrypt
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 
   erpnext-nginx:
     image: frappe/erpnext-nginx:${ERPNEXT_VERSION}
@@ -133,8 +133,8 @@ services:
 
   site-creator:
     image: frappe/erpnext-worker:${ERPNEXT_VERSION}
-    restart: "no"
-    command: "new"
+    restart: no
+    command: new
     depends_on:
       - erpnext-python
     environment:

--- a/docs/single-bench.md
+++ b/docs/single-bench.md
@@ -29,18 +29,28 @@ To get started, copy the existing `env-local` or `env-production` file to `.env`
     - In this case, `edge` corresponds to `develop`. To setup any other version, you may use the branch name or version specific tags. (eg. version-12, v11.1.15, v11).
 - `FRAPPE_VERSION=edge`
     - In this case, `edge` corresponds to `develop`. To setup any other version, you may use the branch name or version specific tags. (eg. version-12, v11.1.15, v11).
-- `MYSQL_ROOT_PASSWORD=admin`
-    - Bootstraps a MariaDB container with this value set as the root password. If a managed MariaDB instance is used, there is no need to set the password here.
 - `MARIADB_HOST=mariadb`
     - Sets the hostname to `mariadb`. This is required if the database is managed by the containerized MariaDB instance.
+- `MYSQL_ROOT_PASSWORD=admin`
+    - Bootstraps a MariaDB container with this value set as the root password. If a managed MariaDB instance is used, there is no need to set the password here.
     - In case of a separately managed database setups, set the value to the database's hostname/IP/domain.
 - `SITE_NAME=erp.example.com`
     - Creates this site after starting all services and installs ERPNext. Site name is domain name that resolves. e.g. `erp.example.com` or `mysite.localhost`
 - ``SITES=`erp.example.com` ``
     - List of sites that are part of the deployment "bench" Each site is separated by a comma(,) and quoted in backtick (`). By default site created by ``SITE_NAME`` variable is added here.
     - If LetsEncrypt is being setup, make sure that the DNS for all the site's domains correctly point to the current instance.
+- `DB_ROOT_USER=root`
+    - MariaDB root username
+- `ADMIN_PASSWORD=admin`
+    - Password for the `Administrator` user, credentials after install `Administrator:$ADMIN_PASSWORD`.
+- `INSTALL_APPS=erpnext`
+    - Apps to install, the app must be already in the container image, to install other application read the [instructions on installing custom apps](./custom-apps-for-production.md).
 - `LETSENCRYPT_EMAIL=email@example.com`
     - Email for LetsEncrypt expiry notification. This is only required if you are setting up LetsEncrypt.
+- `ENTRYPOINT_LABEL=traefik.http.routers.erpnext-nginx.entrypoints=websecure`
+    - Related to the traefik configuration, says all traffic from outside should come from HTTP or HTTPS, for local development should be web, for production websecure. if redirection is needed, read below.
+- `CERT_RESOLVER_LABEL=traefik.http.routers.erpnext-nginx.tls.certresolver=myresolver`
+    - Which traefik resolver to use to get TLS certificate, this variable **should only be set in production.**
 
 Notes:
 
@@ -49,7 +59,7 @@ Notes:
 
 ### HTTP to HTTPS redirection
 
-> Recommended only for **production**
+> This step can be skipped, Recommended only for **production**
 
 If HTTPS redirection is required, add the following labels block to the **traefik** service/container. This will route any HTTP traffic to HTTPS. (e.g any request going to `http://ernext.example.com` will be redirected to `https://erpnext.example.com`)
 
@@ -80,6 +90,8 @@ Make sure to replace `<project-name>` with the desired name you wish to set for 
 
 Notes:
 
+- If it's the first time running, and site is being initialized, *it can take multiple minutes for the site to be up*
+- After the site is ready the username is `Administrator` and the password is `$ADMIN_PASSWORD`
 - The local deployment is for testing and REST API development purpose only
 - A complete development environment is available [here](../development)
 - The site names are limited to patterns matching \*.localhost by default

--- a/docs/single-bench.md
+++ b/docs/single-bench.md
@@ -47,6 +47,27 @@ Notes:
 - `AUTO_MIGRATE` variable is set to `1` by default. It checks if there is semver bump or git hash change in case of develop branch and automatically migrates the sites on container start up.
 - It is good practice to use image tag for specific version instead of latest. e.g `frappe-socketio:v12.5.1`, `erpnext-nginx:v12.7.1`.
 
+### HTTP to HTTPS redirection
+
+> Recommended only for **production**
+
+If HTTPS redirection is required, add the following labels block to the **traefik** service/container. This will route any HTTP traffic to HTTPS. (e.g any request going to `http://ernext.example.com` will be redirected to `https://erpnext.example.com`)
+
+```yaml
+    # ...
+    labels:
+      # enable traefik
+      - "traefik.enable=true"
+      # global redirect to https
+      - "traefik.http.routers.http-catchall.rule=hostregexp(`{host:.+}`)"
+      - "traefik.http.routers.http-catchall.entrypoints=web"
+      - "traefik.http.routers.http-catchall.middlewares=redirect-to-https"
+
+      # middleware redirect
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+    # ...
+```
+
 ## Start containers
 
 Execute the following command:

--- a/docs/single-bench.md
+++ b/docs/single-bench.md
@@ -50,7 +50,15 @@ To get started, copy the existing `env-local` or `env-production` file to `.env`
 - `ENTRYPOINT_LABEL=traefik.http.routers.erpnext-nginx.entrypoints=websecure`
     - Related to the traefik configuration, says all traffic from outside should come from HTTP or HTTPS, for local development should be web, for production websecure. if redirection is needed, read below.
 - `CERT_RESOLVER_LABEL=traefik.http.routers.erpnext-nginx.tls.certresolver=myresolver`
-    - Which traefik resolver to use to get TLS certificate, this variable **should only be set in production.**
+    - Which traefik resolver to use to get TLS certificate, sets `erpnext.local.no-cert-resolver` for local setup.
+- ``HTTPS_REDIRECT_RULE_LABEL=traefik.http.routers.http-catchall.rule=hostregexp(`{host:.+}`) ``
+    - Related to the traefik https redirection configuration, sets `erpnext.local.no-redirect-rule` for local setup.
+- `HTTPS_REDIRECT_ENTRYPOINT_LABEL=traefik.http.routers.http-catchall.entrypoints=web`
+    - Related to the traefik https redirection configuration, sets `erpnext.local.no-entrypoint` for local setup.
+- `HTTPS_REDIRECT_MIDDLEWARE_LABEL=traefik.http.routers.http-catchall.middlewares=redirect-to-https`
+    - Related to the traefik https redirection configuration, sets `erpnext.local.no-middleware` for local setup.
+- `HTTPS_USE_REDIRECT_MIDDLEWARE_LABEL=traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https`
+    - Related to the traefik https redirection configuration, sets `erpnext.local-no-redirect-middleware` for local setup.
 
 Notes:
 

--- a/docs/single-bench.md
+++ b/docs/single-bench.md
@@ -57,27 +57,6 @@ Notes:
 - `AUTO_MIGRATE` variable is set to `1` by default. It checks if there is semver bump or git hash change in case of develop branch and automatically migrates the sites on container start up.
 - It is good practice to use image tag for specific version instead of latest. e.g `frappe-socketio:v12.5.1`, `erpnext-nginx:v12.7.1`.
 
-### HTTP to HTTPS redirection
-
-> This step can be skipped, Recommended only for **production**
-
-If HTTPS redirection is required, add the following labels block to the **traefik** service/container. This will route any HTTP traffic to HTTPS. (e.g any request going to `http://ernext.example.com` will be redirected to `https://erpnext.example.com`)
-
-```yaml
-    # ...
-    labels:
-      # enable traefik
-      - "traefik.enable=true"
-      # global redirect to https
-      - "traefik.http.routers.http-catchall.rule=hostregexp(`{host:.+}`)"
-      - "traefik.http.routers.http-catchall.entrypoints=web"
-      - "traefik.http.routers.http-catchall.middlewares=redirect-to-https"
-
-      # middleware redirect
-      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
-    # ...
-```
-
 ## Start containers
 
 Execute the following command:
@@ -90,7 +69,7 @@ Make sure to replace `<project-name>` with the desired name you wish to set for 
 
 Notes:
 
-- If it's the first time running, and site is being initialized, *it can take multiple minutes for the site to be up*
+- If it is the first time running and site is being initialized, *it can take multiple minutes for the site to be up*. Monitor `site-creator` container logs to check progress. Use command `docker logs <project-name>_site-creator_1 -f`
 - After the site is ready the username is `Administrator` and the password is `$ADMIN_PASSWORD`
 - The local deployment is for testing and REST API development purpose only
 - A complete development environment is available [here](../development)

--- a/env-local
+++ b/env-local
@@ -9,3 +9,8 @@ DB_ROOT_USER=root
 ADMIN_PASSWORD=admin
 INSTALL_APPS=erpnext
 ENTRYPOINT_LABEL=traefik.http.routers.erpnext-nginx.entrypoints=web
+CERT_RESOLVER_LABEL=erpnext.local.no-cert-resolver
+HTTPS_REDIRECT_RULE_LABEL=erpnext.local.no-redirect-rule
+HTTPS_REDIRECT_ENTRYPOINT_LABEL=erpnext.local.no-entrypoint
+HTTPS_REDIRECT_MIDDLEWARE_LABEL=erpnext.local.no-middleware
+HTTPS_USE_REDIRECT_MIDDLEWARE_LABEL=erpnext.local-no-redirect-middleware

--- a/env-production
+++ b/env-production
@@ -10,3 +10,7 @@ ADMIN_PASSWORD=admin
 INSTALL_APPS=erpnext
 ENTRYPOINT_LABEL=traefik.http.routers.erpnext-nginx.entrypoints=websecure
 CERT_RESOLVER_LABEL=traefik.http.routers.erpnext-nginx.tls.certresolver=myresolver
+HTTPS_REDIRECT_RULE_LABEL=traefik.http.routers.http-catchall.rule=hostregexp(`{host:.+}`)
+HTTPS_REDIRECT_ENTRYPOINT_LABEL=traefik.http.routers.http-catchall.entrypoints=web
+HTTPS_REDIRECT_MIDDLEWARE_LABEL=traefik.http.routers.http-catchall.middlewares=redirect-to-https
+HTTPS_USE_REDIRECT_MIDDLEWARE_LABEL=traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https


### PR DESCRIPTION
In the compose file, removed some quotes for everything to be the same. And in the documentation added HTTP > HTTPS redirection instructions and explained the missing environment variables. Also added a note about the initial site creation time and the default credentials.