### PR TITLE
fix: use remote_addr instead of header ip

### DIFF
--- a/build/common/nginx-default.conf.template
+++ b/build/common/nginx-default.conf.template
@@ -50,7 +50,7 @@ server {
     }
 
     location @webserver {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Frappe-Site-Name $host;
         proxy_set_header Host $http_host;


### PR DESCRIPTION
Implements the fix talked about in #261 and on [frappe/bench/pull/1024](https://github.com/frappe/bench/pull/1024).