### PR TITLE
fix: custom compose build context

### DIFF
--- a/installation/docker-compose-custom.yml
+++ b/installation/docker-compose-custom.yml
@@ -4,11 +4,10 @@ services:
   [app]-assets:
     image: [app]-assets
     build:
-      context: . 
-      dockerfile: ./build/[app]-assets/Dockerfile
+      context: ../build/[app]-nginx
     restart: on-failure
     environment:
-      - FRAPPE_PY=erpnext-python
+      - FRAPPE_PY=[app]-python
       - FRAPPE_PY_PORT=8000
       - FRAPPE_SOCKETIO=frappe-socketio
       - SOCKETIO_PORT=9000
@@ -34,8 +33,7 @@ services:
   [app]-python:
     image: [app]-worker
     build:
-      context: . 
-      dockerfile: ./build/[app]-worker/Dockerfile
+      context: ../build/[app]-worker
     restart: on-failure
     environment:
       - MARIADB_HOST=${MARIADB_HOST}


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

I was unable to `docker-compose up` with custom apps. The reason was that the custom app build files were unreachable from the previous context of `.` which was the path at which `docker-compose-custom.yml` was present. Besides, I thought it better to confine the context to just what the build requires, hence the change in respective contexts.
