### PR TITLE
feat: profit off HTTP caching

### DIFF
--- a/build/erpnext-nginx/Dockerfile
+++ b/build/erpnext-nginx/Dockerfile
@@ -12,6 +12,7 @@ FROM frappe/frappe-nginx:${GIT_BRANCH}
 COPY --from=0 /home/frappe/frappe-bench/sites/ /var/www/html/
 COPY --from=0 /rsync /rsync
 RUN echo "erpnext" >> /var/www/html/apps.txt
+RUN touch -m /var/www/html/.build
 
 VOLUME [ "/assets" ]
 

--- a/build/frappe-nginx/Dockerfile
+++ b/build/frappe-nginx/Dockerfile
@@ -33,6 +33,7 @@ COPY --from=0 /home/frappe/frappe-bench/sites /var/www/html/
 COPY --from=0 /var/www/error_pages /var/www/
 COPY build/common/nginx-default.conf.template /etc/nginx/conf.d/default.conf.template
 COPY build/frappe-nginx/docker-entrypoint.sh /
+RUN touch -m /var/www/html/.build
 
 RUN apt-get update && apt-get install -y rsync && apt-get clean \
     && echo "#!/bin/bash" > /rsync \


### PR DESCRIPTION
Without a `.build` file, the assets served get a random `build_version` on every request. Benefits from `Cache-Control` headers are not utilized. 
https://github.com/frappe/frappe/blob/cac7cc402fa8e28120284ae49a6cff0fb8681c38/frappe/www/desk.py#L85-L91

I added the command to `touch .build` in the _Dockerfile_. But I don't know whether it would be more appropriate to do this in _install_app.sh_.