### PR TITLE
fix: nginx config

### DIFF
--- a/build/common/nginx-default.conf.template
+++ b/build/common/nginx-default.conf.template
@@ -30,7 +30,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header X-Frappe-Site-Name $host;
-        proxy_set_header Origin $http_referer;
+        proxy_set_header Origin $scheme://$http_host;
         proxy_set_header Host $http_host;
 
         proxy_pass http://socketio-server;


### PR DESCRIPTION
use $scheme://$http_host instead of $http_referer
fixes socketio

revert https://github.com/frappe/frappe_docker/pull/232
that caused socketio to take host as https://example.com/desk instead of https://example.com

error:

```
100.64.0.39 - - [06/Jul/2020:07:20:07 +0000] "GET /desk/api/method/frappe.realtime.can_subscribe_doc?sid=07da11decda89b875008331f420420420thccbdcbdthccbd16775a&doctype=Selling%20Settings&docname=Selling%20Settings HTTP/1.1" 404 2530 "-" "-" "100.64.1.82"
```