### PR TITLE
feat: touch .build

### DIFF
--- a/build/frappe-nginx/docker-entrypoint.sh
+++ b/build/frappe-nginx/docker-entrypoint.sh
@@ -13,6 +13,8 @@ rsync -a --delete /var/www/html/assets/frappe /assets
 
 chmod -R 755 /assets
 
+touch /var/www/html/sites/.build -r $(ls -td /assets/* | head -n 1)
+
 if [[ -z "$FRAPPE_PY" ]]; then
     export FRAPPE_PY=0.0.0.0
 fi


### PR DESCRIPTION
Continued from #299.

This sets the `.build` modified time to the newest modified times of all the folders in `/assets`. Every time any of the assets are rebuilt, their modified time updates which in turn does the same to `.build`.

Sorry couldn't update this sooner.
