### PR TITLE
build: Allow cached layer for install_packages git python2

### DIFF
--- a/build/erpnext-nginx/Dockerfile
+++ b/build/erpnext-nginx/Dockerfile
@@ -2,6 +2,9 @@ ARG NODE_IMAGE_TAG=12-prod
 ARG GIT_BRANCH=develop
 FROM bitnami/node:${NODE_IMAGE_TAG}
 
+# make it faster (cached layer) for next "/install_app" step
+RUN install_packages git python2
+
 ARG GIT_BRANCH
 COPY build/erpnext-nginx/install_app.sh /install_app
 


### PR DESCRIPTION
Related to #320

> Please provide enough information so that others can review your pull request:

Since `install_packages git python2` is run by `install_app.sh`, better make it part of the previous Docker layer, saves time for slow internet users (like me).

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
