### PR TITLE
Use new version variables in compose files

### DIFF
--- a/env-example
+++ b/env-example
@@ -1,4 +1,5 @@
-VERSION=edge
+ERPNEXT_VERSION=edge
+FRAPPE_VERSION=edge
 MARIADB_HOST=mariadb
 MYSQL_ROOT_PASSWORD=admin
 SITES=your.domain.com

--- a/installation/docker-compose-custom.yml
+++ b/installation/docker-compose-custom.yml
@@ -46,7 +46,7 @@ services:
       - assets-vol:/home/frappe/frappe-bench/sites/assets:rw
 
   frappe-socketio:
-    image: frappe/frappe-socketio:${VERSION}
+    image: frappe/frappe-socketio:${FRAPPE_VERSION}
     restart: on-failure
     depends_on:
       - redis-socketio

--- a/installation/docker-compose-erpnext.yml
+++ b/installation/docker-compose-erpnext.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   erpnext-nginx:
-    image: frappe/erpnext-nginx:${VERSION}
+    image: frappe/erpnext-nginx:${ERPNEXT_VERSION}
     restart: on-failure
     environment:
       - FRAPPE_PY=erpnext-python
@@ -29,7 +29,7 @@ services:
       - assets-vol:/assets:rw
 
   erpnext-python:
-    image: frappe/erpnext-worker:${VERSION}
+    image: frappe/erpnext-worker:${ERPNEXT_VERSION}
     restart: on-failure
     environment:
       - MARIADB_HOST=${MARIADB_HOST}
@@ -43,7 +43,7 @@ services:
       - assets-vol:/home/frappe/frappe-bench/sites/assets:rw
 
   frappe-socketio:
-    image: frappe/frappe-socketio:${VERSION}
+    image: frappe/frappe-socketio:${FRAPPE_VERSION}
     restart: on-failure
     depends_on:
       - redis-socketio
@@ -53,7 +53,7 @@ services:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
 
   frappe-worker-default:
-    image: frappe/erpnext-worker:${VERSION}
+    image: frappe/erpnext-worker:${ERPNEXT_VERSION}
     restart: on-failure
     command: worker
     depends_on:
@@ -66,7 +66,7 @@ services:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
 
   frappe-worker-short:
-    image: frappe/erpnext-worker:${VERSION}
+    image: frappe/erpnext-worker:${ERPNEXT_VERSION}
     restart: on-failure
     command: worker
     environment:
@@ -81,7 +81,7 @@ services:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
 
   frappe-worker-long:
-    image: frappe/erpnext-worker:${VERSION}
+    image: frappe/erpnext-worker:${ERPNEXT_VERSION}
     restart: on-failure
     command: worker
     environment:
@@ -96,7 +96,7 @@ services:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
 
   frappe-schedule:
-    image: frappe/erpnext-worker:${VERSION}
+    image: frappe/erpnext-worker:${ERPNEXT_VERSION}
     restart: on-failure
     command: schedule
     depends_on:

--- a/installation/docker-compose-frappe.yml
+++ b/installation/docker-compose-frappe.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   frappe-nginx:
-    image: frappe/frappe-nginx:${VERSION}
+    image: frappe/frappe-nginx:${FRAPPE_VERSION}
     restart: on-failure
     environment:
       - FRAPPE_PY=frappe-python
@@ -29,7 +29,7 @@ services:
       - assets-vol:/assets:rw
 
   frappe-python:
-    image: frappe/frappe-worker:${VERSION}
+    image: frappe/frappe-worker:${FRAPPE_VERSION}
     restart: on-failure
     environment:
       - MARIADB_HOST=${MARIADB_HOST}
@@ -43,7 +43,7 @@ services:
       - assets-vol:/home/frappe/frappe-bench/sites/assets:rw
 
   frappe-socketio:
-    image: frappe/frappe-socketio:${VERSION}
+    image: frappe/frappe-socketio:${FRAPPE_VERSION}
     restart: on-failure
     depends_on:
       - redis-socketio
@@ -53,7 +53,7 @@ services:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
 
   frappe-worker-default:
-    image: frappe/frappe-worker:${VERSION}
+    image: frappe/frappe-worker:${FRAPPE_VERSION}
     restart: on-failure
     command: worker
     depends_on:
@@ -66,7 +66,7 @@ services:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
 
   frappe-worker-short:
-    image: frappe/frappe-worker:${VERSION}
+    image: frappe/frappe-worker:${FRAPPE_VERSION}
     restart: on-failure
     command: worker
     environment:
@@ -81,7 +81,7 @@ services:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
 
   frappe-worker-long:
-    image: frappe/frappe-worker:${VERSION}
+    image: frappe/frappe-worker:${FRAPPE_VERSION}
     restart: on-failure
     command: worker
     environment:
@@ -96,7 +96,7 @@ services:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
 
   frappe-schedule:
-    image: frappe/frappe-worker:${VERSION}
+    image: frappe/frappe-worker:${FRAPPE_VERSION}
     restart: on-failure
     command: schedule
     depends_on:


### PR DESCRIPTION
When updating our ERPNext deployment, I noticed that you made progress on Kubernetes support. It seems that you introduced more specific version variables for this, namely `FRAPPE_VERSION` and `ERPNEXT_VERSION`.

However, I noticed that the docker-compose files still use the old `VERSION` variable. I replaced them with the correct one so that they work with the new version variables.