### PR TITLE
fix: do not consider directory objects

### DIFF
--- a/build/common/commands/push_backup.py
+++ b/build/common/commands/push_backup.py
@@ -74,6 +74,8 @@ def delete_old_backups(limit, bucket, site_name):
         for obj in objects.get('CommonPrefixes'):
             if obj.get('Prefix') == bucket_dir + '/':
                 for backup_obj in bucket.objects.filter(Prefix=obj.get('Prefix')):
+                    if backup_obj.get()["ContentType"] == "application/x-directory":
+                        continue
                     try:
                         # backup_obj.key is bucket_dir/site/date_time/backupfile.extension
                         bucket_dir, site_slug, date_time, backupfile = backup_obj.key.split('/')

--- a/build/common/commands/restore_backup.py
+++ b/build/common/commands/restore_backup.py
@@ -116,6 +116,8 @@ def pull_backup_from_s3():
     download_backups = []
 
     for obj in bucket.objects.filter(Prefix=bucket_dir):
+        if obj.get()["ContentType"] == "application/x-directory":
+            continue
         backup_file = obj.key.replace(os.path.join(bucket_dir, ''), '')
         backup_files.append(backup_file)
         site_name, timestamp, backup_type = backup_file.split('/')


### PR DESCRIPTION
If the backups are stored inside some directory in S3, it is also included in the object list and the line where key is split and assigned to vars break since its a directory object and we only need the desired file inside it.