### PR TITLE
Update documentation about Honcho's ProcFile (redis is already not included)

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -75,7 +75,7 @@ bench set-redis-socketio-host redis-socketio:6379
 
 ### Edit Honcho's Procfile
 
-Note : With the option '--skip-redis-config-generation' during bench init, this part is no more needed. But at least, take a look to ProcFile to see what going on when bench launch honcho on start
+Note : With the option '--skip-redis-config-generation' during bench init, these actions are no more needed. But at least, take a look to ProcFile to see what going on when bench launch honcho on start command
 
 Honcho is the tool used by Bench to manage all the processes Frappe requires. Usually, these all run in localhost, but in this case, we have external containers for Redis. For this reason, we have to stop Honcho from trying to start Redis processes.
 

--- a/development/README.md
+++ b/development/README.md
@@ -73,7 +73,7 @@ bench set-redis-queue-host redis-queue:6379
 bench set-redis-socketio-host redis-socketio:6379
 ```
 
-### Edit Honcho's Procfile (if you didn't use "--skip-redis-config-generation"" option during bench init)
+### Edit Honcho's Procfile
 
 Honcho is the tool used by Bench to manage all the processes Frappe requires. Usually, these all run in localhost, but in this case, we have external containers for Redis. For this reason, we have to stop Honcho from trying to start Redis processes.
 
@@ -87,6 +87,8 @@ Or running the following command:
 ```shell
 sed -i '/redis/d' ./Procfile
 ```
+
+Note: with the option '--skip-redis-config-generation' during bench init, this part is no more needed. But at least, take a look to ProcFile to see what going on when bench launch honcho on start
 
 ### Create a new site with bench
 

--- a/development/README.md
+++ b/development/README.md
@@ -75,6 +75,8 @@ bench set-redis-socketio-host redis-socketio:6379
 
 ### Edit Honcho's Procfile
 
+Note : With the option '--skip-redis-config-generation' during bench init, this part is no more needed. But at least, take a look to ProcFile to see what going on when bench launch honcho on start
+
 Honcho is the tool used by Bench to manage all the processes Frappe requires. Usually, these all run in localhost, but in this case, we have external containers for Redis. For this reason, we have to stop Honcho from trying to start Redis processes.
 
 Open the Procfile file and remove the three lines containing the configuration from Redis, either by editing manually the file:
@@ -87,8 +89,6 @@ Or running the following command:
 ```shell
 sed -i '/redis/d' ./Procfile
 ```
-
-Note: with the option '--skip-redis-config-generation' during bench init, this part is no more needed. But at least, take a look to ProcFile to see what going on when bench launch honcho on start
 
 ### Create a new site with bench
 

--- a/development/README.md
+++ b/development/README.md
@@ -73,7 +73,7 @@ bench set-redis-queue-host redis-queue:6379
 bench set-redis-socketio-host redis-socketio:6379
 ```
 
-### Edit Honcho's Procfile
+### Edit Honcho's Procfile (if you didn't use "--skip-redis-config-generation"" option during bench init)
 
 Honcho is the tool used by Bench to manage all the processes Frappe requires. Usually, these all run in localhost, but in this case, we have external containers for Redis. For this reason, we have to stop Honcho from trying to start Redis processes.
 


### PR DESCRIPTION
Since the option --skip-redis-config-generation for bench init do not put redis config into ProcFile this step is not needed for developpement environement