### PR TITLE
fix: make new command compatible with MySQL 8

### DIFF
--- a/build/common/commands/new.py
+++ b/build/common/commands/new.py
@@ -93,7 +93,10 @@ def main():
         if config.get(RDS_DB) or site_config.get(RDS_DB):
             grant_privileges = RDS_PRIVILEGES
 
-        command = mysql_command + [f"GRANT {grant_privileges} ON `{db_name}`.* TO '{db_name}'@'%' IDENTIFIED BY '{db_password}'; FLUSH PRIVILEGES;"]
+        command = mysql_command + [f"\
+            CREATE USER IF NOT EXISTS '{db_name}'@'%' IDENTIFIED BY '{db_password}'; \
+            GRANT {grant_privileges} ON `{db_name}`.* TO '{db_name}'@'%'; \
+            FLUSH PRIVILEGES;"]
         run_command(command)
 
     if frappe.redis_server:


### PR DESCRIPTION
Starting with MySQL 8, we no longer can (implicitly) create a user using the `GRANT` command. we should Use `CREATE USER` instead followed by the GRANT statement.