### PR TITLE
fix: install app failed when APP_NAME is not same as the one containe…

### DIFF
--- a/build/common/worker/install_app.sh
+++ b/build/common/worker/install_app.sh
@@ -12,5 +12,5 @@ cd ./apps
 
 [ "${APP_BRANCH}" ] && BRANCH="-b ${APP_BRANCH}"
 
-git clone --depth 1 -o upstream ${APP_REPO} ${BRANCH}
+git clone --depth 1 -o upstream ${APP_REPO} ${BRANCH} ${APP_NAME}
 pip3 install --no-cache-dir -e /home/frappe/frappe-bench/apps/${APP_NAME}

--- a/build/erpnext-nginx/install_app.sh
+++ b/build/erpnext-nginx/install_app.sh
@@ -15,7 +15,7 @@ install_packages git python2
 mkdir -p apps
 cd apps
 git clone --depth 1 https://github.com/frappe/frappe ${BRANCH}
-git clone --depth 1 ${APP_REPO} ${BRANCH}
+git clone --depth 1 ${APP_REPO} ${BRANCH} ${APP_NAME}
 
 cd /home/frappe/frappe-bench/apps/frappe
 yarn


### PR DESCRIPTION
install app failed when `APP_NAME` is not same as the one contained in `APP_REPO`