### PR TITLE
feat(frappe-nginx): configurable nginx http timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ It takes care of the following:
     1. [Docker Swarm](docs/docker-swarm.md)
     2. [Kubernetes](https://helm.erpnext.com)
 3. [Site Operations](docs/site-operations.md)
-4. [Custom apps for production](docs/custom-apps-for-production.md)
-5. [Tips for moving deployments](docs/tips-for-moving-deployments.md)
+4. [Environment Variables](docs/environment-variables.md)
+5. [Custom apps for production](docs/custom-apps-for-production.md)
+6. [Tips for moving deployments](docs/tips-for-moving-deployments.md)
 
 ## Development Setup
 

--- a/build/common/nginx-default.conf.template
+++ b/build/common/nginx-default.conf.template
@@ -55,7 +55,7 @@ server {
         proxy_set_header X-Frappe-Site-Name $host;
         proxy_set_header Host $http_host;
         proxy_set_header X-Use-X-Accel-Redirect True;
-        proxy_read_timeout 120;
+        proxy_read_timeout ${HTTP_TIMEOUT};
         proxy_redirect off;
 
         proxy_pass  http://frappe-server;

--- a/build/frappe-nginx/docker-entrypoint.sh
+++ b/build/frappe-nginx/docker-entrypoint.sh
@@ -31,12 +31,15 @@ if [[ -z "$SOCKETIO_PORT" ]]; then
     export SOCKETIO_PORT=9000
 fi
 
-envsubst '${API_HOST}
-    ${API_PORT}
-    ${FRAPPE_PY}
+if [[ -z "$HTTP_TIMEOUT" ]]; then
+    export HTTP_TIMEOUT=120
+fi
+
+envsubst '${FRAPPE_PY}
     ${FRAPPE_PY_PORT}
     ${FRAPPE_SOCKETIO}
-    ${SOCKETIO_PORT}' \
+    ${SOCKETIO_PORT}
+    ${HTTP_TIMEOUT}' \
     < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 
 echo "Waiting for frappe-python to be available on $FRAPPE_PY port $FRAPPE_PY_PORT"

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,22 @@
+List of environment variables for containers
+
+### frappe-worker and erpnext-worker
+
+Following environment variables are set into sites volume as `common_site_config.json`. It means once the file is created in volume, the variables won't have any effect, you need to edit the common_site_config.json to update the configuration
+
+- `DB_HOST`: MariaDB host, domain name or ip address.
+- `DB_PORT`: MariaDB port.
+- `REDIS_CACHE`: Redis cache host, domain name or ip address.
+- `REDIS_QUEUE`: Redis queue host, domain name or ip address.
+- `REDIS_SOCKETIO`: Redis queue host, domain name or ip address.
+- `SOCKETIO_PORT: `: Port on which the SocketIO should start.
+
+### frappe-nginx and erpnext-nginx
+
+These variables are set on every container start. Change in these variables will reflect on every container start.
+
+- `FRAPPE_PY`: Gunicorn host to reverse proxy. Default: 0.0.0.0
+- `FRAPPE_PY_PORT`: Gunicorn port to reverse proxy. Default: 8000
+- `FRAPPE_SOCKETIO`: SocketIO host to reverse proxy. Default: 0.0.0.0
+- `SOCKETIO_PORT`: SocketIO port to reverse proxy. Default: 9000
+- `HTTP_TIMEOUT`: Nginx http timeout. Default: 120

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -20,3 +20,7 @@ These variables are set on every container start. Change in these variables will
 - `FRAPPE_SOCKETIO`: SocketIO host to reverse proxy. Default: 0.0.0.0
 - `SOCKETIO_PORT`: SocketIO port to reverse proxy. Default: 9000
 - `HTTP_TIMEOUT`: Nginx http timeout. Default: 120
+
+### frappe-socketio
+
+This container takes configuration from `common_site_config.json` which is already created by erpnext gunicorn container. It doesn't use any environment variables.


### PR DESCRIPTION
nginx timeout can be configured using `HTTP_TIMEOUT` environment variable.
