### PR TITLE
feat: make images arm64 compatible

### DIFF
--- a/build/bench/Dockerfile
+++ b/build/bench/Dockerfile
@@ -1,8 +1,8 @@
 # Frappe Bench Dockerfile
-FROM bitnami/minideb:latest
+FROM debian:buster-slim
 LABEL author=frappé
 
-RUN install_packages \
+RUN apt-get update -y && apt-get install  \
     git \
     wkhtmltopdf \
     mariadb-client \
@@ -49,14 +49,18 @@ RUN install_packages \
     python3-setuptools \
     python3-tk \
     python-virtualenv \
-    less
+    less -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
   && dpkg-reconfigure --frontend=noninteractive locales
 
-# Install wkhtmltox correctly
-RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.buster_amd64.deb
-RUN dpkg -i wkhtmltox_0.12.5-1.buster_amd64.deb && rm wkhtmltox_0.12.5-1.buster_amd64.deb
+# Detect arch, download and install wkhtmltox
+RUN if [ `uname -m` = 'aarch64' ]; then export ARCH=arm64; fi \
+    && if [ `uname -m` = 'x86_64' ]; then export ARCH=amd64; fi \
+    && wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_${ARCH}.deb \
+    && dpkg -i wkhtmltox_0.12.6-1.buster_${ARCH}.deb && rm wkhtmltox_0.12.6-1.buster_${ARCH}.deb
 
 # Create new user with home directory, improve docker compatibility with UID/GID 1000, add user to sudo group, allow passwordless sudo, switch to that user and change directory to user home directory
 RUN groupadd -g 1000 frappe
@@ -89,7 +93,7 @@ ENV NODE_VERSION=12.20.0
 ENV NODE_VERSION_FRAPPEV11=10.23.0
 
 # Install nvm with node
-RUN wget https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh
+RUN wget https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh
 RUN chmod +x install.sh
 RUN ./install.sh
 ENV NVM_DIR=/home/frappe/.nvm

--- a/build/erpnext-nginx/Dockerfile
+++ b/build/erpnext-nginx/Dockerfile
@@ -1,13 +1,19 @@
-ARG NODE_IMAGE_TAG=12-prod
+ARG NODE_IMAGE_TAG=12-buster-slim
 ARG GIT_BRANCH=develop
-FROM bitnami/node:${NODE_IMAGE_TAG}
+ARG DOCKER_REGISTRY_PREFIX=frappe
+FROM node:${NODE_IMAGE_TAG}
 
 ARG GIT_BRANCH
 COPY build/erpnext-nginx/install_app.sh /install_app
+RUN chmod +x /install_app && \
+  apt-get update -y && \
+  apt-get install build-essential git python2 -y && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
 RUN /install_app erpnext https://github.com/frappe/erpnext ${GIT_BRANCH}
 
-FROM frappe/frappe-nginx:${GIT_BRANCH}
+FROM ${DOCKER_REGISTRY_PREFIX}/frappe-nginx:${GIT_BRANCH}
 
 COPY --from=0 /home/frappe/frappe-bench/sites/ /var/www/html/
 COPY --from=0 /rsync /rsync

--- a/build/erpnext-nginx/install_app.sh
+++ b/build/erpnext-nginx/install_app.sh
@@ -10,8 +10,6 @@ mkdir -p /home/frappe/frappe-bench/sites/assets
 cd /home/frappe/frappe-bench
 echo -e "frappe\n${APP_NAME}" > /home/frappe/frappe-bench/sites/apps.txt
 
-install_packages git python2
-
 mkdir -p apps
 cd apps
 git clone --depth 1 https://github.com/frappe/frappe ${BRANCH}
@@ -20,9 +18,7 @@ git clone --depth 1 ${APP_REPO} ${BRANCH} ${APP_NAME}
 cd /home/frappe/frappe-bench/apps/frappe
 yarn
 yarn production --app ${APP_NAME}
-rm -fr node_modules
 yarn install --production=true
-yarn add node-sass
 
 mkdir -p /home/frappe/frappe-bench/sites/assets/${APP_NAME}
 cp -R /home/frappe/frappe-bench/apps/${APP_NAME}/${APP_NAME}/public/* /home/frappe/frappe-bench/sites/assets/${APP_NAME}

--- a/build/erpnext-worker/Dockerfile
+++ b/build/erpnext-worker/Dockerfile
@@ -1,5 +1,6 @@
 ARG GIT_BRANCH=develop
-FROM frappe/frappe-worker:${GIT_BRANCH}
+ARG DOCKER_REGISTRY_PREFIX=frappe
+FROM ${DOCKER_REGISTRY_PREFIX}/frappe-worker:${GIT_BRANCH}
 
 ARG GIT_BRANCH
 RUN install_app erpnext https://github.com/frappe/erpnext ${GIT_BRANCH}

--- a/build/frappe-nginx/Dockerfile
+++ b/build/frappe-nginx/Dockerfile
@@ -2,13 +2,16 @@
 # This is done to ensures that node-sass binary remains common.
 # node-sass is required to enable website theme feature used
 # by Website Manager role in Frappe Framework
-FROM bitnami/python:3.7-prod
+FROM python:3.7-slim-buster
 
 ENV NVM_DIR=/root/.nvm
 ENV NODE_VERSION=12.20.0
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
-RUN install_packages wget \
-    && wget https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh \
+RUN apt-get update -y \
+    && apt-get install wget python2 git build-essential -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && wget https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh \
     && chmod +x install.sh \
     && ./install.sh \
     && . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION} \
@@ -18,8 +21,6 @@ WORKDIR /home/frappe/frappe-bench
 RUN mkdir -p /home/frappe/frappe-bench/sites \
     && echo "frappe" > /home/frappe/frappe-bench/sites/apps.txt
 
-RUN install_packages git
-
 ARG GIT_BRANCH=develop
 RUN mkdir -p apps sites/assets/css  \
     && cd apps \
@@ -28,7 +29,6 @@ RUN mkdir -p apps sites/assets/css  \
 RUN cd /home/frappe/frappe-bench/apps/frappe \
     && yarn \
     && yarn run production \
-    && rm -fr node_modules \
     && yarn install --production=true
 
 RUN node --version \

--- a/build/frappe-socketio/Dockerfile
+++ b/build/frappe-socketio/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim
+FROM node:buster-slim
 
 # Add frappe user
 RUN useradd -ms /bin/bash frappe

--- a/build/frappe-worker/Dockerfile
+++ b/build/frappe-worker/Dockerfile
@@ -1,11 +1,10 @@
-FROM bitnami/python:3.7-prod
+FROM python:3.7-slim-buster
 
 # Add non root user without password
-RUN sed -i 's/^PASS_MAX_DAYS.*/PASS_MAX_DAYS    -1/' /etc/login.defs \
-    && sed -i 's/^PASS_MIN_DAYS.*/PASS_MIN_DAYS    -1/' /etc/login.defs \
-    && useradd -ms /bin/bash frappe
+RUN useradd -ms /bin/bash frappe
 
 ARG GIT_BRANCH=develop
+ARG ARCH=amd64
 ENV PYTHONUNBUFFERED 1
 ENV NVM_DIR=/home/frappe/.nvm
 ENV NODE_VERSION=12.20.0
@@ -13,12 +12,14 @@ ENV PATH="/home/frappe/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
 # Install dependencies
 WORKDIR /home/frappe/frappe-bench
-RUN install_packages \
+RUN apt-get update -y && apt-get install \
+    # for frappe framework
     git \
     mariadb-client \
     postgresql-client \
     gettext-base \
     wget \
+    wait-for-it \
     # for PDF
     libjpeg62-turbo \
     libx11-6 \
@@ -29,13 +30,21 @@ RUN install_packages \
     fonts-cantarell \
     xfonts-75dpi \
     xfonts-base \
+    libxml2 \
+    libffi-dev \
+    libjpeg-dev \
+    zlib1g-dev \
     # For psycopg2
     libpq-dev \
-    wait-for-it \
-    && wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.buster_amd64.deb \
-    && dpkg -i wkhtmltox_0.12.5-1.buster_amd64.deb && rm wkhtmltox_0.12.5-1.buster_amd64.deb \
-    && wget https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh \
-    && apt-get purge -y wget && apt-get autoremove -y \
+    # For arm64 python wheel builds
+    gcc \
+    g++ -y \
+    # Detect arch, download and install wkhtmltox
+    && if [ `uname -m` = 'aarch64' ]; then export ARCH=arm64; fi \
+    && if [ `uname -m` = 'x86_64' ]; then export ARCH=amd64; fi \
+    && wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_${ARCH}.deb \
+    && dpkg -i wkhtmltox_0.12.6-1.buster_${ARCH}.deb && rm wkhtmltox_0.12.6-1.buster_${ARCH}.deb \
+    && wget https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh \
     && chown -R frappe:frappe /home/frappe
 
 USER frappe


### PR DESCRIPTION
- Images are made compatible
- No automated builds yet. User will need to build on their own.
- Reason for no automated builds is: pandas takes 2+ hrs to build on arm64. Travis has job running limit for 50 min.
- DOCKER_REGISTRY_PREFIX can be used as build-arg by forks for automated builds.

Github actions has more timeout limit to run jobs. Project can be moved there for automated builds?
Anyway 2+ hrs to build something (2+ x3 for v13,v12,v11) is not sustainable?

