### PR TITLE
Allow for configuring the realip module for nginx to pass the proper IP/Scheme to frappe

### DIFF
--- a/build/common/nginx-default.conf.template
+++ b/build/common/nginx-default.conf.template
@@ -6,6 +6,12 @@ upstream socketio-server {
     server ${FRAPPE_SOCKETIO}:${SOCKETIO_PORT} fail_timeout=0;
 }
 
+# Parse the X-Forwarded-Proto header - if set - defaulting to $scheme.
+map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+    default $scheme;
+    https https;
+}
+
 server {
     listen 80;
     server_name $http_host;
@@ -15,6 +21,12 @@ server {
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";
+
+    # Define ${UPSTREAM_REAL_IP_ADDRESS} as our trusted upstream address, so we will be using
+    # its ${UPSTREAM_REAL_IP_HEADER} address as our remote address
+    set_real_ip_from ${UPSTREAM_REAL_IP_ADDRESS};
+    real_ip_header ${UPSTREAM_REAL_IP_HEADER};
+    real_ip_recursive ${UPSTREAM_REAL_IP_RECURSIVE};
 
     location /assets {
         try_files $uri =404;
@@ -27,10 +39,12 @@ server {
 
     location /socket.io {
         proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header X-Frappe-Site-Name $host;
-        proxy_set_header Origin $scheme://$http_host;
+        proxy_set_header Origin $proxy_x_forwarded_proto://$http_host;
         proxy_set_header Host $http_host;
 
         proxy_pass http://socketio-server;
@@ -50,8 +64,8 @@ server {
     }
 
     location @webserver {
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
         proxy_set_header X-Frappe-Site-Name $host;
         proxy_set_header Host $http_host;
         proxy_set_header X-Use-X-Accel-Redirect True;

--- a/build/frappe-nginx/docker-entrypoint.sh
+++ b/build/frappe-nginx/docker-entrypoint.sh
@@ -35,11 +35,26 @@ if [[ -z "$HTTP_TIMEOUT" ]]; then
     export HTTP_TIMEOUT=120
 fi
 
+if [[ -z "$UPSTREAM_REAL_IP_ADDRESS" ]]; then
+    export UPSTREAM_REAL_IP_ADDRESS=127.0.0.1
+fi
+
+if [[ -z "$UPSTREAM_REAL_IP_RECURSIVE" ]]; then
+    export UPSTREAM_REAL_IP_RECURSIVE=off
+fi
+
+if [[ -z "$UPSTREAM_REAL_IP_HEADER" ]]; then
+    export UPSTREAM_REAL_IP_HEADER="X-Forwarded-For"
+fi
+
 envsubst '${FRAPPE_PY}
     ${FRAPPE_PY_PORT}
     ${FRAPPE_SOCKETIO}
     ${SOCKETIO_PORT}
-    ${HTTP_TIMEOUT}' \
+    ${HTTP_TIMEOUT}
+    ${UPSTREAM_REAL_IP_ADDRESS}
+    ${UPSTREAM_REAL_IP_RECURSIVE}
+    ${UPSTREAM_REAL_IP_HEADER}' \
     < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 
 echo "Waiting for frappe-python to be available on $FRAPPE_PY port $FRAPPE_PY_PORT"

--- a/docs/docker-swarm.md
+++ b/docs/docker-swarm.md
@@ -142,6 +142,7 @@ services:
   erpnext-nginx:
     image: frappe/erpnext-nginx:${ERPNEXT_VERSION?Variable ERPNEXT_VERSION not set}
     environment:
+      - UPSTREAM_REAL_IP_ADDRESS=10.0.0.0/8
       - FRAPPE_PY=erpnext-python
       - FRAPPE_PY_PORT=8000
       - FRAPPE_SOCKETIO=frappe-socketio

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -20,6 +20,9 @@ These variables are set on every container start. Change in these variables will
 - `FRAPPE_SOCKETIO`: SocketIO host to reverse proxy. Default: 0.0.0.0
 - `SOCKETIO_PORT`: SocketIO port to reverse proxy. Default: 9000
 - `HTTP_TIMEOUT`: Nginx http timeout. Default: 120
+- `UPSTREAM_REAL_IP_ADDRESS `: The trusted address (or ip range) of upstream proxy servers. If set, this will tell nginx to trust the X-Forwarded-For header from these proxy servers in determining the real IP address of connecting clients. Default: 127.0.0.1
+- `UPSTREAM_REAL_IP_RECURSIVE`: When set to `on`, this will tell nginx to not just look to the last upstream proxy server in determining the real IP address. Default: off
+- `UPSTREAM_REAL_IP_HEADER`: Set this to the header name sent by your upstream proxy server to indicate the real IP of connecting clients. Default: X-Forwarded-For
 
 ### frappe-socketio
 


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Currently, frappe-nginx (and subsequently erpnext-nginx) don't report the proper IP/scheme when placed behind a traefik instance.

These changes configure the [nginx real-ip module](http://nginx.org/en/docs/http/ngx_http_realip_module.html) to allow the X-Forwarded-For and X-Forwarded-Proto headers sent by traefik (and other loadbalancers) to be used. 

This enables 3 new environment variables that can be passed:
- UPSTREAM_REAL_IP_ADDRESS  to configure the trusted IP range (to avoid IP spoofing). By default this is 127.0.0.1, but for docker this can be set to 172.17. 0.0/16 (non-swarm) or 10.0.0.0/8 (swarm), or whatever loadbalancer/proxy IP range is being used.
- UPSTREAM_REAL_IP_RECURSIVE to configure the real_ip_recursive directive. This is mostly useful when behind nexted loadbalancers (i.e. AWS ELB => Traefik => frappe-nginx). This is off by default.
- UPSTREAM_REAL_IP_HEADER to configure which header will be used to obtain the original IP address from. By default we use X-Forwarded-For, but in some cases one might want to use X-Real-IP.

This change also adds the X-Forwarded-For and X-Forwarded-Proto headers for the socket-io endpoint, so that it is also aware of the real origin IP/protocol.