### PR TITLE
Rootless containers by default

### DIFF
--- a/build/common/worker/docker-entrypoint.sh
+++ b/build/common/worker/docker-entrypoint.sh
@@ -46,8 +46,8 @@ function configureEnv() {
 }
 
 function checkConnection() {
-  su frappe -c ". /home/frappe/frappe-bench/env/bin/activate \
-    && python /home/frappe/frappe-bench/commands/check_connection.py"
+  . /home/frappe/frappe-bench/env/bin/activate \
+    && python /home/frappe/frappe-bench/commands/check_connection.py
 }
 
 function checkConfigExists() {
@@ -68,9 +68,6 @@ if [[ ! -e /home/frappe/frappe-bench/sites/apps.txt ]]; then
   find /home/frappe/frappe-bench/apps -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -r > /home/frappe/frappe-bench/sites/apps.txt
 fi
 
-# Allow user process to create files in logs directory
-chown -R frappe:frappe /home/frappe/frappe-bench/logs
-
 # symlink node_modules
 ln -sfn /home/frappe/frappe-bench/sites/assets/frappe/node_modules \
   /home/frappe/frappe-bench/apps/frappe/node_modules
@@ -78,8 +75,6 @@ ln -sfn /home/frappe/frappe-bench/sites/assets/frappe/node_modules \
 if [ "$1" = 'start' ]; then
   configureEnv
   checkConnection
-
-  chown frappe:frappe /home/frappe/frappe-bench/sites/common_site_config.json
 
   if [[ -z "$WORKERS" ]]; then
     export WORKERS=2
@@ -90,99 +85,67 @@ if [ "$1" = 'start' ]; then
   fi
 
   if [[ ! -z "$AUTO_MIGRATE" ]]; then
-    su frappe -c ". /home/frappe/frappe-bench/env/bin/activate \
-      && python /home/frappe/frappe-bench/commands/auto_migrate.py"
+    . /home/frappe/frappe-bench/env/bin/activate \
+      && python /home/frappe/frappe-bench/commands/auto_migrate.py
   fi
 
-  if [[ -z "$RUN_AS_ROOT" ]]; then
-    su frappe -c ". /home/frappe/frappe-bench/env/bin/activate \
-      && gunicorn -b 0.0.0.0:$FRAPPE_PORT \
-      --worker-tmp-dir /dev/shm \
-      --threads=4 \
-      --workers $WORKERS \
-      --worker-class=gthread \
-      --log-file=- \
-      -t 120 frappe.app:application --preload"
-  else
-    . /home/frappe/frappe-bench/env/bin/activate
-    gunicorn -b 0.0.0.0:$FRAPPE_PORT \
-      --worker-tmp-dir /dev/shm \
-      --threads=4 \
-      --workers $WORKERS \
-      --worker-class=gthread \
-      --log-file=- \
-      -t 120 frappe.app:application --preload
-  fi
+  . /home/frappe/frappe-bench/env/bin/activate
+  gunicorn -b 0.0.0.0:$FRAPPE_PORT \
+    --worker-tmp-dir /dev/shm \
+    --threads=4 \
+    --workers $WORKERS \
+    --worker-class=gthread \
+    --log-file=- \
+    -t 120 frappe.app:application --preload
 
 elif [ "$1" = 'worker' ]; then
   checkConfigExists
   checkConnection
   # default WORKER_TYPE=default
-  if [[ -z "$RUN_AS_ROOT" ]]; then
-    su frappe -c ". /home/frappe/frappe-bench/env/bin/activate \
-      && python /home/frappe/frappe-bench/commands/worker.py"
-  else
-    . /home/frappe/frappe-bench/env/bin/activate
-    python /home/frappe/frappe-bench/commands/worker.py
-  fi
+  
+  . /home/frappe/frappe-bench/env/bin/activate
+  python /home/frappe/frappe-bench/commands/worker.py
 
 elif [ "$1" = 'schedule' ]; then
   checkConfigExists
   checkConnection
-  if [[ -z "$RUN_AS_ROOT" ]]; then
-    su frappe -c ". /home/frappe/frappe-bench/env/bin/activate \
-      && python /home/frappe/frappe-bench/commands/background.py"
-  else
-    . /home/frappe/frappe-bench/env/bin/activate
-    python /home/frappe/frappe-bench/commands/background.py
-  fi
+  
+  . /home/frappe/frappe-bench/env/bin/activate
+  python /home/frappe/frappe-bench/commands/background.py
 
 elif [ "$1" = 'new' ]; then
   checkConfigExists
   checkConnection
-  if [[ -z "$RUN_AS_ROOT" ]]; then
-    su frappe -c ". /home/frappe/frappe-bench/env/bin/activate \
-      && python /home/frappe/frappe-bench/commands/new.py"
-    exit
-  else
-    . /home/frappe/frappe-bench/env/bin/activate
-    python /home/frappe/frappe-bench/commands/new.py
-  fi
+  
+  . /home/frappe/frappe-bench/env/bin/activate
+  python /home/frappe/frappe-bench/commands/new.py
+  exit
 
 elif [ "$1" = 'drop' ]; then
   checkConfigExists
   checkConnection
-  if [[ -z "$RUN_AS_ROOT" ]]; then
-    su frappe -c ". /home/frappe/frappe-bench/env/bin/activate \
-      && python /home/frappe/frappe-bench/commands/drop.py"
-    exit
-  else
-    . /home/frappe/frappe-bench/env/bin/activate
-    python /home/frappe/frappe-bench/commands/drop.py
-  fi
+  
+  . /home/frappe/frappe-bench/env/bin/activate
+  python /home/frappe/frappe-bench/commands/drop.py
+  exit
 
 elif [ "$1" = 'migrate' ]; then
 
-  su frappe -c ". /home/frappe/frappe-bench/env/bin/activate \
-    && python /home/frappe/frappe-bench/commands/migrate.py"
+  . /home/frappe/frappe-bench/env/bin/activate \
+    && python /home/frappe/frappe-bench/commands/migrate.py
   exit
 
 elif [ "$1" = 'doctor' ]; then
 
-  su frappe -c ". /home/frappe/frappe-bench/env/bin/activate \
-    && python /home/frappe/frappe-bench/commands/doctor.py ${@:2}"
+  . /home/frappe/frappe-bench/env/bin/activate \
+    && python /home/frappe/frappe-bench/commands/doctor.py ${@:2}
   exit
 
 elif [ "$1" = 'backup' ]; then
 
-  if [[ -z "$RUN_AS_ROOT" ]]; then
-    su frappe -c ". /home/frappe/frappe-bench/env/bin/activate \
-      && python /home/frappe/frappe-bench/commands/backup.py"
-    exit
-  else
-    . /home/frappe/frappe-bench/env/bin/activate
-    python /home/frappe/frappe-bench/commands/backup.py
-  fi
+  . /home/frappe/frappe-bench/env/bin/activate
+  python /home/frappe/frappe-bench/commands/backup.py
+  exit
 
 elif [ "$1" = 'console' ]; then
 
@@ -192,25 +155,20 @@ elif [ "$1" = 'console' ]; then
     exit 1
   fi
 
-  if [[ -z "$RUN_AS_ROOT" ]]; then
-    su frappe -c ". /home/frappe/frappe-bench/env/bin/activate \
-      && python /home/frappe/frappe-bench/commands/console.py $2"
-    exit
-  else
-    . /home/frappe/frappe-bench/env/bin/activate
-    python /home/frappe/frappe-bench/commands/console.py "$2"
-  fi
+  . /home/frappe/frappe-bench/env/bin/activate
+  python /home/frappe/frappe-bench/commands/console.py "$2"
+  exit
 
 elif [ "$1" = 'push-backup' ]; then
 
-  su frappe -c ". /home/frappe/frappe-bench/env/bin/activate \
-    && python /home/frappe/frappe-bench/commands/push_backup.py"
+  . /home/frappe/frappe-bench/env/bin/activate \
+    && python /home/frappe/frappe-bench/commands/push_backup.py
   exit
 
 elif [ "$1" = 'restore-backup' ]; then
 
-  su frappe -c ". /home/frappe/frappe-bench/env/bin/activate \
-    && python /home/frappe/frappe-bench/commands/restore_backup.py"
+  . /home/frappe/frappe-bench/env/bin/activate \
+    && python /home/frappe/frappe-bench/commands/restore_backup.py
   exit
 
 else

--- a/build/frappe-nginx/docker-entrypoint.sh
+++ b/build/frappe-nginx/docker-entrypoint.sh
@@ -11,8 +11,6 @@ rsync -a --delete /var/www/html/assets/css /assets
 rsync -a --delete /var/www/html/assets/frappe /assets
 . /rsync
 
-chmod -R 755 /assets
-
 touch /var/www/html/sites/.build -r $(ls -td /assets/* | head -n 1)
 
 if [[ -z "$FRAPPE_PY" ]]; then

--- a/build/frappe-socketio/Dockerfile
+++ b/build/frappe-socketio/Dockerfile
@@ -28,6 +28,8 @@ RUN cd /home/frappe/frappe-bench/apps/frappe \
 COPY build/frappe-socketio/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN ln -s /usr/local/bin/docker-entrypoint.sh / # backwards compat
 
+USER frappe
+
 WORKDIR /home/frappe/frappe-bench/sites
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/build/frappe-socketio/docker-entrypoint.sh
+++ b/build/frappe-socketio/docker-entrypoint.sh
@@ -16,14 +16,14 @@ function checkConfigExists() {
 
 if [ "$1" = 'start' ]; then
   checkConfigExists
-  su frappe -c "node /home/frappe/frappe-bench/apps/frappe/socketio.js"
+  node /home/frappe/frappe-bench/apps/frappe/socketio.js
 
 elif [ "$1" = 'doctor' ]; then
 
-  su frappe -c "node /home/frappe/frappe-bench/apps/frappe/health.js"
+  node /home/frappe/frappe-bench/apps/frappe/health.js
 
 else
 
-  exec su frappe -c "$@"
+  exec -c "$@"
 
 fi

--- a/build/frappe-worker/Dockerfile
+++ b/build/frappe-worker/Dockerfile
@@ -47,6 +47,10 @@ RUN apt-get update -y && apt-get install \
     && wget https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh \
     && chown -R frappe:frappe /home/frappe
 
+# Setup docker-entrypoint
+COPY build/common/worker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN ln -s /usr/local/bin/docker-entrypoint.sh / # backwards compat
+
 USER frappe
 # Install nvm with node
 RUN bash install.sh \
@@ -65,7 +69,6 @@ RUN python -m venv env \
     && git clone --depth 1 -o upstream https://github.com/frappe/frappe --branch ${GIT_BRANCH} \
     && pip3 install --no-cache-dir -e /home/frappe/frappe-bench/apps/frappe
 
-USER root
 # Copy scripts and templates
 COPY build/common/commands/* /home/frappe/frappe-bench/commands/
 COPY build/common/common_site_config.json.template /opt/frappe/common_site_config.json.template
@@ -73,17 +76,10 @@ COPY build/common/worker/install_app.sh /usr/local/bin/install_app
 COPY build/common/worker/bench /usr/local/bin/bench
 COPY build/common/worker/healthcheck.sh /usr/local/bin/healthcheck.sh
 
-# Setup docker-entrypoint
-COPY build/common/worker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-RUN ln -s /usr/local/bin/docker-entrypoint.sh / # backwards compat
-
 # Use sites volume as working directory
 WORKDIR /home/frappe/frappe-bench/sites
 
-# Set ownership of sites directory
-RUN chown -R frappe:frappe /home/frappe/frappe-bench/sites
-
-VOLUME [ "/home/frappe/frappe-bench/sites", "/home/frappe/backups" ]
+VOLUME [ "/home/frappe/frappe-bench/sites", "/home/frappe/backups", "/home/frappe/frappe-bench/logs" ]
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - redis-socketio
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   erpnext-worker-default:
     image: frappe/erpnext-worker:${ERPNEXT_VERSION}
@@ -78,6 +79,7 @@ services:
       - redis-cache
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   erpnext-worker-short:
     image: frappe/erpnext-worker:${ERPNEXT_VERSION}
@@ -90,6 +92,7 @@ services:
       - redis-cache
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   erpnext-worker-long:
     image: frappe/erpnext-worker:${ERPNEXT_VERSION}
@@ -112,6 +115,7 @@ services:
       - redis-cache
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   redis-cache:
     image: redis:latest
@@ -154,6 +158,7 @@ services:
       - INSTALL_APPS=${INSTALL_APPS}
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
 volumes:
   mariadb-vol:
@@ -163,3 +168,4 @@ volumes:
   assets-vol:
   sites-vol:
   cert-vol:
+  logs-vol:

--- a/frappe-installer
+++ b/frappe-installer
@@ -244,7 +244,4 @@ check_env
 
 prompt_config
 setup_user
-
-su - "$username" << EOF
 install
-EOF

--- a/installation/docker-compose-custom.yml
+++ b/installation/docker-compose-custom.yml
@@ -43,6 +43,7 @@ services:
       - SOCKETIO_PORT=9000
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
       - assets-vol:/home/frappe/frappe-bench/sites/assets:rw
 
   frappe-socketio:
@@ -54,6 +55,7 @@ services:
       - redis-socketio
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   frappe-worker-default:
     image: [app]-worker
@@ -67,6 +69,7 @@ services:
       - redis-cache
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   frappe-worker-short:
     image: [app]-worker
@@ -82,6 +85,7 @@ services:
       - redis-cache
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   frappe-worker-long:
     image: [app]-worker
@@ -97,6 +101,7 @@ services:
       - redis-cache
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   frappe-schedule:
     image: [app]-worker
@@ -110,7 +115,9 @@ services:
       - redis-cache
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
 volumes:
   assets-vol:
   sites-vol:
+  logs-vol:

--- a/installation/docker-compose-erpnext.yml
+++ b/installation/docker-compose-erpnext.yml
@@ -41,6 +41,7 @@ services:
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
       - assets-vol:/home/frappe/frappe-bench/sites/assets:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   frappe-socketio:
     image: frappe/frappe-socketio:${FRAPPE_VERSION}
@@ -51,6 +52,7 @@ services:
       - redis-socketio
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   frappe-worker-default:
     image: frappe/erpnext-worker:${ERPNEXT_VERSION}
@@ -64,6 +66,7 @@ services:
       - redis-cache
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   frappe-worker-short:
     image: frappe/erpnext-worker:${ERPNEXT_VERSION}
@@ -79,6 +82,7 @@ services:
       - redis-cache
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   frappe-worker-long:
     image: frappe/erpnext-worker:${ERPNEXT_VERSION}
@@ -94,6 +98,7 @@ services:
       - redis-cache
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   frappe-schedule:
     image: frappe/erpnext-worker:${ERPNEXT_VERSION}
@@ -107,7 +112,9 @@ services:
       - redis-cache
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
 volumes:
   assets-vol:
   sites-vol:
+  logs-vol:

--- a/installation/docker-compose-frappe.yml
+++ b/installation/docker-compose-frappe.yml
@@ -40,6 +40,7 @@ services:
       - AUTO_MIGRATE=1
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
       - assets-vol:/home/frappe/frappe-bench/sites/assets:rw
 
   frappe-socketio:
@@ -51,6 +52,7 @@ services:
       - redis-socketio
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   frappe-worker-default:
     image: frappe/frappe-worker:${FRAPPE_VERSION}
@@ -64,6 +66,7 @@ services:
       - redis-cache
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   frappe-worker-short:
     image: frappe/frappe-worker:${FRAPPE_VERSION}
@@ -79,6 +82,7 @@ services:
       - redis-cache
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   frappe-worker-long:
     image: frappe/frappe-worker:${FRAPPE_VERSION}
@@ -94,6 +98,7 @@ services:
       - redis-cache
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
   frappe-schedule:
     image: frappe/frappe-worker:${FRAPPE_VERSION}
@@ -107,7 +112,9 @@ services:
       - redis-cache
     volumes:
       - sites-vol:/home/frappe/frappe-bench/sites:rw
+      - logs-vol:/home/frappe/frappe-bench/logs:rw
 
 volumes:
   assets-vol:
   sites-vol:
+  logs-vol:


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

This PR introduces rootless containers by default

> Explain the **details** for making this change. What existing problem does the pull request solve?

## Problem

Running docker containers as root is [extremely unsafe](https://americanexpress.io/do-not-run-dockerized-applications-as-root/) and should be avoided at all times unless no other options are available.

When deploying erpnext to a kubernetes cluster I was forced to run all containers as root with all privileges allowed. I noticed that there has been some thought about this and there is an environment variable called `$RUN_AS_ROOT` that allows to perform some actions as a non-root user. However, the use of this variable is sub-optimal because:

- It's not well documented. Indeed, the docker-compose examples that any new developer may use don't even mention the variable
- It's not really effective. Some commands have it and others don't.
- It creates a large amount of conditional branches that are hard to maintain

Crucially, I found that setting `$RUN_AS_ROOT` as 0 would not work because the `checkConnection` function does not include it and so one can end up with a very messy environment where some actions are performed as root and some aren't. 

In my case my problem was double:
- A very inconsistent use of root
- Privilege escalation all over
- Problems with permissions for pretty much everything (is the owner root or the frappe user?)

## Proposed solution

This PR does the following:

1. Removes all privilege escalation statements with `su`. Privilege escalation should only be used for system actions and executing bench commands does seem to require such a high level of permissions
2. Remove all `chown` actions. Again, this is considered a dangerous action during runtime. All file permissions should be handled at build time or by the container runtime (Docker, kubernetes, etc.) and never at runtime. It's much easier to use tried-and-tested approaches. For example, in kubernetes one can use `fsGroup`, an init container, etc.

## Also included

One of the `chown` actions is against the logs directory. This made me realised that there is one extra volume that wasn't declared before with the result that logs are lost when the container is recreated. There is now a new logs volume
