### PR TITLE
feat: Add Site name and Host as env variables for NGINX config template

### DIFF
--- a/build/common/nginx-default.conf.template
+++ b/build/common/nginx-default.conf.template
@@ -43,9 +43,9 @@ server {
         proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_set_header X-Frappe-Site-Name $host;
         proxy_set_header Origin $proxy_x_forwarded_proto://$http_host;
-        proxy_set_header Host $http_host;
+        proxy_set_header X-Frappe-Site-Name ${FRAPPE_SITE_NAME_HEADER};
+        proxy_set_header Host ${HTTP_HOST};
 
         proxy_pass http://socketio-server;
     }
@@ -66,8 +66,8 @@ server {
     location @webserver {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
-        proxy_set_header X-Frappe-Site-Name $host;
-        proxy_set_header Host $http_host;
+        proxy_set_header X-Frappe-Site-Name ${FRAPPE_SITE_NAME_HEADER};
+        proxy_set_header Host ${HTTP_HOST};
         proxy_set_header X-Use-X-Accel-Redirect True;
         proxy_read_timeout ${HTTP_TIMEOUT};
         proxy_redirect off;

--- a/build/frappe-nginx/docker-entrypoint.sh
+++ b/build/frappe-nginx/docker-entrypoint.sh
@@ -45,6 +45,15 @@ if [[ -z "$UPSTREAM_REAL_IP_HEADER" ]]; then
     export UPSTREAM_REAL_IP_HEADER="X-Forwarded-For"
 fi
 
+if [[ -z "$FRAPPE_SITE_NAME_HEADER" ]]; then
+    export FRAPPE_SITE_NAME_HEADER="\$host"
+fi
+
+if [[ -z "$HTTP_HOST" ]]; then
+    export HTTP_HOST="\$http_host"
+fi
+
+
 envsubst '${FRAPPE_PY}
     ${FRAPPE_PY_PORT}
     ${FRAPPE_SOCKETIO}
@@ -52,6 +61,8 @@ envsubst '${FRAPPE_PY}
     ${HTTP_TIMEOUT}
     ${UPSTREAM_REAL_IP_ADDRESS}
     ${UPSTREAM_REAL_IP_RECURSIVE}
+    ${FRAPPE_SITE_NAME_HEADER}
+    ${HTTP_HOST}
     ${UPSTREAM_REAL_IP_HEADER}' \
     < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -24,6 +24,8 @@ These variables are set on every container start. Change in these variables will
 - `UPSTREAM_REAL_IP_ADDRESS `: The trusted address (or ip range) of upstream proxy servers. If set, this will tell nginx to trust the X-Forwarded-For header from these proxy servers in determining the real IP address of connecting clients. Default: 127.0.0.1
 - `UPSTREAM_REAL_IP_RECURSIVE`: When set to `on`, this will tell nginx to not just look to the last upstream proxy server in determining the real IP address. Default: off
 - `UPSTREAM_REAL_IP_HEADER`: Set this to the header name sent by your upstream proxy server to indicate the real IP of connecting clients. Default: X-Forwarded-For
+- `FRAPPE_SITE_NAME_HEADER`: NGINX `X-Frappe-Site-Name` header in the HTTP request which matches a site name. Default: `$host`
+- `HTTP_HOST`: NGINX `Host` header in the HTTP request which matches a site name. Default: `$http_host`
 
 ### frappe-socketio
 


### PR DESCRIPTION
The custom NGINX image doesn't allow to set static Host/Site-Name headers. This is required if the app is exposed to an AWS ALB which can't send these headers for doing the healthchecks. Since the healthchecks fail, the target groups are not activated, thus giving 502.

For such environments, the host header has to be hardcoded inside the NGINX config. This change is backwards compatible since it fallbacks to using the original variables inside the config template, only overrides if the user gives them as environment variables in their `docker-compose` configs.
