### PR TITLE
Add a flag to skip generating default NGINX config

### DIFF
--- a/build/frappe-nginx/docker-entrypoint.sh
+++ b/build/frappe-nginx/docker-entrypoint.sh
@@ -53,18 +53,27 @@ if [[ -z "$HTTP_HOST" ]]; then
     export HTTP_HOST="\$http_host"
 fi
 
+if [[ -z "$SKIP_NGINX_TEMPLATE_GENERATION" ]]; then
+    export SKIP_NGINX_TEMPLATE_GENERATION=0
+fi
 
-envsubst '${FRAPPE_PY}
-    ${FRAPPE_PY_PORT}
-    ${FRAPPE_SOCKETIO}
-    ${SOCKETIO_PORT}
-    ${HTTP_TIMEOUT}
-    ${UPSTREAM_REAL_IP_ADDRESS}
-    ${UPSTREAM_REAL_IP_RECURSIVE}
-    ${FRAPPE_SITE_NAME_HEADER}
-    ${HTTP_HOST}
-    ${UPSTREAM_REAL_IP_HEADER}' \
-    < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+if [[ $SKIP_NGINX_TEMPLATE_GENERATION -eq 1 ]]
+then
+  echo "Skipping default NGINX template generation. Please mount your own NGINX config file inside /etc/nginx/conf.d"
+else
+  echo "Generating default template"
+  envsubst '${FRAPPE_PY}
+        ${FRAPPE_PY_PORT}
+        ${FRAPPE_SOCKETIO}
+        ${SOCKETIO_PORT}
+        ${HTTP_TIMEOUT}
+        ${UPSTREAM_REAL_IP_ADDRESS}
+        ${UPSTREAM_REAL_IP_RECURSIVE}
+        ${FRAPPE_SITE_NAME_HEADER}
+        ${HTTP_HOST}
+        ${UPSTREAM_REAL_IP_HEADER}' \
+        < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+fi
 
 echo "Waiting for frappe-python to be available on $FRAPPE_PY port $FRAPPE_PY_PORT"
 timeout 10 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done' $FRAPPE_PY $FRAPPE_PY_PORT

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -26,6 +26,7 @@ These variables are set on every container start. Change in these variables will
 - `UPSTREAM_REAL_IP_HEADER`: Set this to the header name sent by your upstream proxy server to indicate the real IP of connecting clients. Default: X-Forwarded-For
 - `FRAPPE_SITE_NAME_HEADER`: NGINX `X-Frappe-Site-Name` header in the HTTP request which matches a site name. Default: `$host`
 - `HTTP_HOST`: NGINX `Host` header in the HTTP request which matches a site name. Default: `$http_host`
+- `SKIP_NGINX_TEMPLATE_GENERATION`: When set to `1`, this will not generate a default NGINX configuration. The config file must be mounted inside the container (`/etc/nginx/conf.d`) by the user in this case. Default: `0`
 
 ### frappe-socketio
 


### PR DESCRIPTION
Adds `SKIP_NGINX_TEMPLATE_GENERATION` environment variable support to [`frappe-nginx/docker-entrypoint.sh`](https://github.com/frappe/frappe_docker/blob/develop/build/frappe-nginx/docker-entrypoint.sh). The behavior is:

- When set to `1`, will skip the `envsubst` part and the user is expected to mount their own config file.
- Default (`0`), will continue the current behavior of generating the config file from [`nginx-default.conf.template`](https://github.com/frappe/frappe_docker/blob/develop/build/common/nginx-default.conf.template).

Discussed in https://github.com/frappe/frappe_docker/pull/441#issuecomment-808213783. **Marking it as WIP since I'd need to rebase** this once https://github.com/frappe/frappe_docker/pull/441 gets merged.
