### PR TITLE
fix: do not install frappe during app install

### DIFF
--- a/build/common/worker/install_app.sh
+++ b/build/common/worker/install_app.sh
@@ -13,4 +13,10 @@ cd ./apps
 [ "${APP_BRANCH}" ] && BRANCH="-b ${APP_BRANCH}"
 
 git clone --depth 1 -o upstream ${APP_REPO} ${BRANCH} ${APP_NAME}
+
+# Do not install frappe
+sed -i '/frappe/d' ${APP_NAME}/requirements.txt
+
 pip3 install --no-cache-dir -e /home/frappe/frappe-bench/apps/${APP_NAME}
+
+cd ${APP_NAME} && git checkout .


### PR DESCRIPTION
For https://github.com/frappe/frappe_docker/issues/464

Workaround seems like hack