### PR TITLE
fix: quick start userns_mode set to host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     volumes:
       - cert-vol:/letsencrypt
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    userns_mode: "host"
 
   erpnext-nginx:
     image: frappe/erpnext-nginx:${ERPNEXT_VERSION}


### PR DESCRIPTION
suggested in issue https://github.com/frappe/frappe_docker/issues/420
