### PR TITLE
Adding INSTALL_APPS=erpnext env variable to docs

### DIFF
--- a/docs/docker-swarm.md
+++ b/docs/docker-swarm.md
@@ -279,6 +279,7 @@ SITES=`site1.example.com`,`site2.example.com`
 6. Env variables:
     - MYSQL_ROOT_PASSWORD=longsecretpassword
     - SITE_NAME=site1.example.com
+    - INSTALL_APPS=erpnext
 7. Start container
 
 ### Migrate Sites job


### PR DESCRIPTION
Without this variable, erpnext will not be installed when you create a new site job for swarm deployment
