### PR TITLE
fix: rename volume for creating job

### DIFF
--- a/docs/docker-swarm.md
+++ b/docs/docker-swarm.md
@@ -275,7 +275,7 @@ SITES=`site1.example.com`,`site2.example.com`
 2. Select Image frappe/erpnext-worker:v13
 3. Set command as `new`
 4. Select network `frappe-network`
-5. Select Volume `frappe-bench-v13_sites_vol` and mount in container `/home/frappe/frappe-bench/sites`
+5. Select Volume `frappe-bench-v13_sites-vol` and mount in container `/home/frappe/frappe-bench/sites`
 6. Env variables:
     - MYSQL_ROOT_PASSWORD=longsecretpassword
     - SITE_NAME=site1.example.com
@@ -288,7 +288,7 @@ SITES=`site1.example.com`,`site2.example.com`
 2. Select Image frappe/erpnext-worker:v13
 3. Set command as `migrate`
 4. Select network `frappe-network`
-5. Select Volume `frappe-bench-v13_sites_vol` and mount in container `/home/frappe/frappe-bench/sites`
+5. Select Volume `frappe-bench-v13_sites-vol` and mount in container `/home/frappe/frappe-bench/sites`
 6. Env variables:
     - MAINTENANCE_MODE=1
 7. Start container


### PR DESCRIPTION
`frappe-bench-v13_sites_vol` should be `frappe-bench-v13_sites-vol`