### PR TITLE
fix database access errors for new builds

### DIFF
--- a/build/common/commands/new.py
+++ b/build/common/commands/new.py
@@ -64,6 +64,7 @@ def main():
             install_apps=install_apps,
             source_sql=None,
             force=force,
+            no_mariadb_socket=True,
             db_type=db_type,
             reinstall=False,
             db_host=db_host,
@@ -80,6 +81,7 @@ def main():
             install_apps=install_apps,
             source_sql=None,
             force=force,
+            no_mariadb_socket=True,
             reinstall=False,
         )
 


### PR DESCRIPTION
This adds the `no_mariadb_socket` flag for the `site-creator` service.
By adding this flag the frappe framework should now add the sql user using the `%` wildcard to allow the generated frappe user to connect over the docker network fixing #448.