### PR TITLE
fix: Add cups package for PDF font rendering

### DIFF
--- a/build/bench/Dockerfile
+++ b/build/bench/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update -y && apt-get install  \
     fonts-cantarell \
     xfonts-75dpi \
     xfonts-base \
+    cups \
     # to work inside the container
     locales \
     build-essential \


### PR DESCRIPTION
There seems to be a long standing issue with font rendering in PDFs generated by ERPNext (https://discuss.erpnext.com/search?q=pdf%20font).

The issue occurs when using the 'PDF' button, but not when using the 'Print' button, and then using the 'PDF printer' of the browser/OS (https://discuss.erpnext.com/t/discrepancies-between-print-output-and-pdf-output/34643)