### PR TITLE
ci: fix base64 decode of env variable

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -182,7 +182,7 @@ jobs:
         if: needs.resolve-matrix.outputs.build-target == 'stable'
         run: |
           export GIT_SSH_COMMAND="ssh -i ${PWD}/deploy_key"
-          echo -n $HELM_DEPLOY_KEY | base64 -d > deploy_key
+          echo -n $HELM_DEPLOY_KEY | base64 -di > deploy_key
           chmod 400 deploy_key;
           ssh-keyscan github.com >> $HOME/.ssh/known_hosts 2>/dev/null;
           pip install --upgrade pip


### PR DESCRIPTION
use `-i` to ignore garbage. Check https://stackoverflow.com/a/15490765.
