### PR TITLE
ci: fixes ci steps

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,6 +88,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -110,6 +111,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -156,6 +158,7 @@ jobs:
         run: sudo apt-get install -y w3m
 
       - name: Test
+        if: github.event_name == 'pull_request'
         run: |
           ./tests/check-format.sh
           ./tests/docker-test.sh
@@ -180,14 +183,11 @@ jobs:
 
       - name: Release Helm Chart
         if: needs.resolve-matrix.outputs.build-target == 'stable'
+        uses: webfactory/ssh-agent@v0.5.3
+        with:
+          ssh-private-key: ${{ secrets.HELM_DEPLOY_KEY }}
         run: |
-          export GIT_SSH_COMMAND="ssh -i ${PWD}/deploy_key"
-          echo -n $HELM_DEPLOY_KEY | base64 -di > deploy_key
-          chmod 400 deploy_key;
-          ssh-keyscan github.com >> $HOME/.ssh/known_hosts 2>/dev/null;
           pip install --upgrade pip
           git clone git@github.com:frappe/helm.git && cd helm
           pip install -r release_wizard/requirements.txt
           ./release_wizard/wizard 13 patch --remote origin --ci
-        env:
-          HELM_DEPLOY_KEY: ${{ secrets.HELM_DEPLOY_KEY }}


### PR DESCRIPTION
helm release deploy key uses webfactory/ssh-agent@v0.5.3
test only on PR
docker login only if not PR
