### PR TITLE
ci: Push images right after build

### DIFF
--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -60,6 +60,7 @@ jobs:
           files: docker-bake.hcl
           targets: frappe-develop
           load: true
+          push: ${{ github.repository == 'frappe/frappe_docker' && github.event_name != 'pull_request' }}
 
       - name: Build ERPNext images
         uses: docker/bake-action@v1.6.0
@@ -67,22 +68,7 @@ jobs:
           files: docker-bake.hcl
           targets: erpnext-develop
           load: true
+          push: ${{ github.repository == 'frappe/frappe_docker' && github.event_name != 'pull_request' }}
 
       - name: Test
         run: ./.github/scripts/install-deps-and-test.sh
-
-      - name: Push Frappe images
-        if: github.repository == 'frappe/frappe_docker' && github.event_name != 'pull_request'
-        uses: docker/bake-action@v1.6.0
-        with:
-          files: docker-bake.hcl
-          targets: frappe-develop
-          push: true
-
-      - name: Push ERPNext images
-        if: github.repository == 'frappe/frappe_docker' && github.event_name != 'pull_request'
-        uses: docker/bake-action@v1.6.0
-        with:
-          files: docker-bake.hcl
-          targets: erpnext-develop
-          push: true

--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -48,6 +48,7 @@ jobs:
           files: docker-bake.hcl
           targets: frappe-stable
           load: true
+          push: true
 
       - name: Setup ERPNext variables
         run: ./.github/scripts/get-latest-tag.sh
@@ -61,40 +62,11 @@ jobs:
           files: docker-bake.hcl
           targets: erpnext-stable
           load: true
+          push: true
 
       - name: Test
         if: ${{ matrix.version != 12 }}
         run: ./.github/scripts/install-deps-and-test.sh
-
-      - name: Setup Frappe variables
-        if: github.repository == 'frappe/frappe_docker'
-        run: ./.github/scripts/get-latest-tag.sh
-        env:
-          REPO: frappe/frappe
-          VERSION: ${{ matrix.version }}
-
-      - name: Push Frappe images
-        if: github.repository == 'frappe/frappe_docker'
-        uses: docker/bake-action@v1.6.0
-        with:
-          files: docker-bake.hcl
-          targets: frappe-stable
-          push: true
-
-      - name: Setup ERPNext variables
-        if: github.repository == 'frappe/frappe_docker'
-        run: ./.github/scripts/get-latest-tag.sh
-        env:
-          REPO: frappe/erpnext
-          VERSION: ${{ matrix.version }}
-
-      - name: Push ERPNext images
-        if: github.repository == 'frappe/frappe_docker'
-        uses: docker/bake-action@v1.6.0
-        with:
-          files: docker-bake.hcl
-          targets: erpnext-stable
-          push: true
 
       - name: Setup Helm deploy key
         if: github.repository == 'frappe/frappe_docker'


### PR DESCRIPTION
This fixes the bug when ERPNext images are built upon old Frappe images and test are ran on old images.

Closes #541