### PR TITLE
fix(frappe-socketio): Remove dead `doctor` command

### DIFF
--- a/build/frappe-socketio/docker-entrypoint.sh
+++ b/build/frappe-socketio/docker-entrypoint.sh
@@ -1,15 +1,17 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -e
 
 function checkConfigExists() {
   COUNTER=0
   while [[ ! -e /home/frappe/frappe-bench/sites/common_site_config.json && ${COUNTER} -le 30 ]]; do
-    ((COUNTER = COUNTER + 1))
-    echo "config file not created, retry ${COUNTER}"
     sleep 1
+    ((COUNTER = COUNTER + 1))
+    echo "config file not created, retry ${COUNTER}" >&2
   done
 
   if [[ ! -e /home/frappe/frappe-bench/sites/common_site_config.json ]]; then
-    echo "timeout: config file not created"
+    echo "timeout: config file not created" >&2
     exit 1
   fi
 }
@@ -17,11 +19,6 @@ function checkConfigExists() {
 if [[ "$1" == 'start' ]]; then
   checkConfigExists
   node /home/frappe/frappe-bench/apps/frappe/socketio.js
-
-elif [[ "$1" == 'doctor' ]]; then
-  node /home/frappe/frappe-bench/apps/frappe/health.js
-
 else
   exec -c "$@"
-
 fi


### PR DESCRIPTION
There's no file `frappe/health.js`: neither on version-13 nor on develop.

Also updated `checkConfigExists`, now it is the same as in worker entrypoint