### PR TITLE
fix(frappe-worker): Drop flags

### DIFF
--- a/build/frappe-worker/docker-entrypoint.sh
+++ b/build/frappe-worker/docker-entrypoint.sh
@@ -133,19 +133,21 @@ drop)
   : "${DB_ROOT_PASSWORD:=$POSTGRES_PASSWORD}"
   : "${DB_ROOT_PASSWORD:=$MYSQL_ROOT_PASSWORD}"
   : "${DB_ROOT_PASSWORD:=admin}"
-  if [[ -n $NO_BACKUP ]]; then
-    NO_BACKUP=--no-backup
+
+  FLAGS=
+  if [[ ${NO_BACKUP} == 1 ]]; then
+    FLAGS="${FLAGS} --no-backup"
   fi
-  if [[ -n $FORCE ]]; then
-    FORCE=--force
+  if [[ ${FORCE} == 1 ]]; then
+    FLAGS="${FLAGS} --force"
   fi
 
   bench drop-site \
-    $SITE_NAME \
-    --root-login $DB_ROOT_USER \
-    --root-password $DB_ROOT_PASSWORD \
+    ${SITE_NAME} \
+    --root-login ${DB_ROOT_USER} \
+    --root-password ${DB_ROOT_PASSWORD} \
     --archived-sites-path /home/frappe/frappe-bench/sites/archive_sites \
-    $NO_BACKUP $FORCE
+    ${FLAGS}
   ;;
 
 migrate)

--- a/build/frappe-worker/docker-entrypoint.sh
+++ b/build/frappe-worker/docker-entrypoint.sh
@@ -142,6 +142,7 @@ drop)
     FLAGS="${FLAGS} --force"
   fi
 
+  # shellcheck disable=SC2086
   bench drop-site \
     ${SITE_NAME} \
     --root-login ${DB_ROOT_USER} \


### PR DESCRIPTION
If FORCE or NO_BACKUP env variables were set to any value it was counted as True. Now works only: FORCE=1 or NO_BACKUP=1