### PR TITLE
Fix ERPNext build

### DIFF
--- a/build/erpnext-nginx/Dockerfile
+++ b/build/erpnext-nginx/Dockerfile
@@ -10,7 +10,7 @@ ARG GIT_BRANCH=develop
 ARG FRAPPE_BRANCH=${GIT_BRANCH}
 
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python2 \
     git \
     build-essential \

--- a/build/erpnext-nginx/Dockerfile
+++ b/build/erpnext-nginx/Dockerfile
@@ -10,7 +10,7 @@ ARG GIT_BRANCH=develop
 ARG FRAPPE_BRANCH=${GIT_BRANCH}
 
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    && apt-get install --no-install-recommends -y \
     python2 \
     git \
     build-essential \

--- a/build/erpnext-worker/Dockerfile
+++ b/build/erpnext-worker/Dockerfile
@@ -5,4 +5,11 @@ FROM ${DOCKER_REGISTRY_PREFIX}/frappe-worker:${IMAGE_TAG}
 ARG GIT_REPO=https://github.com/frappe/erpnext
 ARG GIT_BRANCH=develop
 
+USER root
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+USER frappe
 RUN install_app erpnext ${GIT_REPO} ${GIT_BRANCH}


### PR DESCRIPTION
After update in #555 we started installing g++ and gcc in frappe-worker image only on arm64. And it is fine because Frappe doesn't require it on different platforms. Turns out ERPNext does. Since erpnext-worker image inherits from frappe-worker build failed.
Currently on PRs build for Frappe and ERPNext are separate, so this issue is explainable. I will see how we can prevent this in the future.

Closes #557.