### PR TITLE
ci: use git command to config git creds

### DIFF
--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -135,7 +135,9 @@ jobs:
           ssh-private-key: ${{ secrets.HELM_DEPLOY_KEY }}
 
       - name: Setup Git Credentials
-        uses: fregante/setup-git-user@v1
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
 
       - name: Release
         run: |


### PR DESCRIPTION
one more attempt to fix #562 

name and email used from this discussion https://github.community/t/github-actions-bot-email-address/17204 and https://github.com/fregante/setup-git-user/blob/6cef8bf084d00360a293e0cc3c56e1b45d6502b8/index.js#L5-L6