### PR TITLE
Fix permission denied error

### DIFF
--- a/build/frappe-worker/Dockerfile
+++ b/build/frappe-worker/Dockerfile
@@ -67,16 +67,12 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then export ARCH=arm64; fi \
     && dpkg -i $downloaded_file \
     && rm $downloaded_file
 
-RUN chown -R frappe:frappe /home/frappe
-
 # Setup docker-entrypoint
 COPY build/frappe-worker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN ln -s /usr/local/bin/docker-entrypoint.sh / # backwards compat
 
 WORKDIR /home/frappe/frappe-bench
-
-RUN chown -R frappe:frappe /home/frappe/frappe-bench
-
+RUN chown -R frappe:frappe /home/frappe
 USER frappe
 
 # Create frappe-bench directories

--- a/build/frappe-worker/Dockerfile
+++ b/build/frappe-worker/Dockerfile
@@ -73,8 +73,11 @@ RUN chown -R frappe:frappe /home/frappe
 COPY build/frappe-worker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN ln -s /usr/local/bin/docker-entrypoint.sh / # backwards compat
 
-USER frappe
 WORKDIR /home/frappe/frappe-bench
+
+RUN chown -R frappe:frappe /home/frappe/frappe-bench
+
+USER frappe
 
 # Create frappe-bench directories
 RUN mkdir -p apps logs commands sites /home/frappe/backups


### PR DESCRIPTION
While building the frappe-worker image, a permissions denied error was being thrown while executing line 80:
`RUN mkdir -p apps logs commands sites /home/frappe/backups`

I now first create the folder as root, change ownership to user frappe before changing to user frappe.