### PR TITLE
Fix nginx bind to port 80 error

### DIFF
--- a/build/frappe-nginx/Dockerfile
+++ b/build/frappe-nginx/Dockerfile
@@ -72,4 +72,5 @@ RUN chown -R nginx:nginx /assets /etc/nginx/conf.d/ /var/www/html/
 USER nginx
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
+USER root
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
This fixes `nginx: [emerg] bind() to 0.0.0.0:80 failed (13: Permission denied)` error as only root user can bind to port 80.