### PR TITLE
Build ERPNext images on top fresh Frappe images

### DIFF
--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -79,6 +79,7 @@ jobs:
           targets: frappe-develop-test
           # load: true      
 
+      - run: docker image ls -a
       - name: Build ERPNext
         uses: docker/bake-action@v1.6.0
         with:

--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -72,50 +72,24 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build
+      - name: Build Frappe
         uses: docker/bake-action@v1.6.0
         with:
           files: docker-bake.hcl
           targets: frappe-develop-test
           load: true
 
-      - name: Test
+      - name: Test Frappe
         run: ./tests/test-frappe.sh
 
-      - name: Push
-        if: env.IS_AUTHORIZED_RUN == 'true'
-        uses: docker/bake-action@v1.6.0
-        with:
-          files: docker-bake.hcl
-          targets: frappe-develop
-          push: true
-
-  build_erpnext:
-    name: ERPNext
-    runs-on: ubuntu-latest
-    needs: build_frappe
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login
-        uses: docker/login-action@v1
-        if: env.IS_AUTHORIZED_RUN == 'true'
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build
+      - name: Build ERPNext
         uses: docker/bake-action@v1.6.0
         with:
           files: docker-bake.hcl
           targets: erpnext-develop-test
           load: true
 
-      - name: Test
+      - name: Test ERPNext
         run: FRAPPE_VERSION=develop ./tests/test-erpnext.sh
 
       - name: Push
@@ -123,5 +97,5 @@ jobs:
         uses: docker/bake-action@v1.6.0
         with:
           files: docker-bake.hcl
-          targets: erpnext-develop
+          targets: frappe-develop,erpnext-develop
           push: true

--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -77,16 +77,14 @@ jobs:
         with:
           files: docker-bake.hcl
           targets: frappe-develop-test
-          # load: true
-      
-      
+          # load: true      
 
       - name: Build ERPNext
         uses: docker/bake-action@v1.6.0
         with:
           files: docker-bake.hcl
           targets: erpnext-develop-test
-          load: true
+          # load: true
 
       - name: Test Frappe
         run: ./tests/test-frappe.sh

--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -79,22 +79,26 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build Frappe
+      - name: Build Frappe and push to local registry
         uses: docker/bake-action@v1.6.0
         with:
           files: docker-bake.hcl
-          targets: frappe-develop-test
-          # load: true
+          targets: frappe-develop-test-localhost
           push: true
 
-      - run: docker image ls -a
       - name: Build ERPNext
         uses: docker/bake-action@v1.6.0
         with:
           files: docker-bake.hcl
           targets: erpnext-develop-test
-          push: true
-          # load: true
+          load: true
+
+      - name: Load Frappe
+        uses: docker/bake-action@v1.6.0
+        with:
+          files: docker-bake.hcl
+          targets: frappe-develop-test
+          load: true
 
       - name: Test Frappe
         run: ./tests/test-frappe.sh

--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -79,12 +79,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build Frappe and push to local registry
+      - name: Build Frappe
         uses: docker/bake-action@v1.6.0
         with:
           files: docker-bake.hcl
-          targets: frappe-develop-test-localhost
+          targets: frappe-develop-test
+          load: true
+
+      - name: Push Frappe to local registry
+        uses: docker/bake-action@v1.6.0
+        with:
+          files: docker-bake.hcl
+          targets: frappe-develop-test-local
           push: true
+
+      - name: Test Frappe
+        run: ./tests/test-frappe.sh
 
       - name: Build ERPNext
         uses: docker/bake-action@v1.6.0
@@ -92,16 +102,6 @@ jobs:
           files: docker-bake.hcl
           targets: erpnext-develop-test
           load: true
-
-      - name: Load Frappe
-        uses: docker/bake-action@v1.6.0
-        with:
-          files: docker-bake.hcl
-          targets: frappe-develop-test
-          load: true
-
-      - name: Test Frappe
-        run: ./tests/test-frappe.sh
 
       - name: Test ERPNext
         run: FRAPPE_VERSION=develop ./tests/test-erpnext.sh

--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -58,12 +58,19 @@ jobs:
   build_main:
     name: Frappe and ERPNext
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
 
       - name: Login
         uses: docker/login-action@v1
@@ -77,7 +84,8 @@ jobs:
         with:
           files: docker-bake.hcl
           targets: frappe-develop-test
-          # load: true      
+          # load: true
+          push: true
 
       - run: docker image ls -a
       - name: Build ERPNext
@@ -85,6 +93,7 @@ jobs:
         with:
           files: docker-bake.hcl
           targets: erpnext-develop-test
+          push: true
           # load: true
 
       - name: Test Frappe

--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -56,7 +56,7 @@ jobs:
           push: true
 
   build_main:
-    name: Frappe and ERPNext
+    name: Frappe & ERPNext
     runs-on: ubuntu-latest
     services:
       registry:

--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -104,7 +104,7 @@ jobs:
           load: true
 
       - name: Test ERPNext
-        run: FRAPPE_VERSION=develop ./tests/test-erpnext.sh
+        run: ./tests/test-erpnext.sh
 
       - name: Push
         if: env.IS_AUTHORIZED_RUN == 'true'

--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -77,12 +77,8 @@ jobs:
         with:
           files: docker-bake.hcl
           targets: frappe-develop-test
-          load: true
+          # load: true
       
-      - run: docker image ls -a
-      # - name: Test Frappe
-      #   run: ./tests/test-frappe.sh
-
       
 
       - name: Build ERPNext
@@ -91,6 +87,9 @@ jobs:
           files: docker-bake.hcl
           targets: erpnext-develop-test
           load: true
+
+      - name: Test Frappe
+        run: ./tests/test-frappe.sh
 
       - name: Test ERPNext
         run: FRAPPE_VERSION=develop ./tests/test-erpnext.sh

--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -55,8 +55,8 @@ jobs:
           targets: bench-build
           push: true
 
-  build_frappe:
-    name: Frappe
+  build_main:
+    name: Frappe and ERPNext
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -78,9 +78,12 @@ jobs:
           files: docker-bake.hcl
           targets: frappe-develop-test
           load: true
+      
+      - run: docker image ls -a
+      # - name: Test Frappe
+      #   run: ./tests/test-frappe.sh
 
-      - name: Test Frappe
-        run: ./tests/test-frappe.sh
+      
 
       - name: Build ERPNext
         uses: docker/bake-action@v1.6.0

--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   build:
-    name: Frappe and ERPNext
+    name: Frappe & ERPNext
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -38,20 +38,22 @@ jobs:
   build:
     name: Frappe and ERPNext
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [12, 13]
     services:
       registry:
         image: registry:2
         ports:
           - 5000:5000
-    strategy:
-      matrix:
-        version: [12, 13]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
 
       - name: Login
         uses: docker/login-action@v1

--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -30,7 +30,7 @@ on:
   repository_dispatch:
 
   workflow_dispatch:
-# TODO: ERPNext image not from right place
+
 env:
   IS_AUTHORIZED_RUN: ${{ github.repository == 'frappe/frappe_docker' && github.event_name != 'pull_request' }}
 

--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -35,13 +35,17 @@ env:
   IS_AUTHORIZED_RUN: ${{ github.repository == 'frappe/frappe_docker' && github.event_name != 'pull_request' }}
 
 jobs:
-  build_frappe:
-    name: Frappe
+  build:
+    name: Frappe and ERPNext
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     strategy:
       matrix:
         version: [12, 13]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -61,14 +65,36 @@ jobs:
         env:
           VERSION: ${{ matrix.version }}
 
-      - name: Build
+      - name: Build Frappe
         uses: docker/bake-action@v1.6.0
         with:
           files: docker-bake.hcl
           targets: frappe-stable-test
           load: true
 
-      - name: Push
+      - name: Push Frappe to local registry
+        uses: docker/bake-action@v1.6.0
+        with:
+          files: docker-bake.hcl
+          targets: frappe-stable-test-local
+          push: true
+
+      - name: Test Frappe
+        if: github.event_name == 'pull_request'
+        run: ./tests/test-frappe.sh
+
+      - name: Build ERPNext
+        uses: docker/bake-action@v1.6.0
+        with:
+          files: docker-bake.hcl
+          targets: erpnext-stable-test
+          load: true
+
+      - name: Test ERPNext
+        if: github.event_name == 'pull_request'
+        run: ./tests/test-erpnext.sh
+
+      - name: Push Frappe
         if: env.IS_AUTHORIZED_RUN == 'true'
         uses: docker/bake-action@v1.6.0
         with:
@@ -78,41 +104,7 @@ jobs:
         env:
           GIT_TAG: ${{ env.FRAPPE_VERSION }}
 
-  build_erpnext:
-    name: ERPNext
-    runs-on: ubuntu-latest
-    needs: build_frappe
-    strategy:
-      matrix:
-        version: [12, 13]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login
-        uses: docker/login-action@v1
-        if: env.IS_AUTHORIZED_RUN == 'true'
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Get latest versions
-        run: ./.github/scripts/get-latest-tags.sh
-        env:
-          VERSION: ${{ matrix.version }}
-
-      - name: Build
-        uses: docker/bake-action@v1.6.0
-        with:
-          files: docker-bake.hcl
-          targets: erpnext-stable-test
-          load: true
-
-      - name: Push
+      - name: Push ERPNext
         if: env.IS_AUTHORIZED_RUN == 'true'
         uses: docker/bake-action@v1.6.0
         with:

--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -30,7 +30,7 @@ on:
   repository_dispatch:
 
   workflow_dispatch:
-
+# TODO: ERPNext image not from right place
 env:
   IS_AUTHORIZED_RUN: ${{ github.repository == 'frappe/frappe_docker' && github.event_name != 'pull_request' }}
 

--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -118,7 +118,7 @@ jobs:
     name: Release Helm
     runs-on: ubuntu-latest
     if: github.repository == 'frappe/frappe_docker' && github.event_name != 'pull_request'
-    needs: [build_frappe, build_erpnext]
+    needs: build
 
     steps:
       - name: Setup deploy key

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -219,6 +219,21 @@ group "erpnext-stable" {
 
 # Test stable images
 
+target "frappe-nginx-stable-test-local" {
+    inherits = ["frappe-nginx-stable"]
+    tags = set_local_test_tags("frappe/frappe-nginx")
+}
+
+target "frappe-worker-stable-test-local" {
+    inherits = ["frappe-worker-stable"]
+    tags = set_local_test_tags("frappe/frappe-worker")
+}
+
+target "frappe-socketio-stable-test-local" {
+    inherits = ["frappe-socketio-stable"]
+    tags = set_local_test_tags("frappe/frappe-socketio")
+}
+
 target "frappe-nginx-stable-test" {
     inherits = ["frappe-nginx-stable"]
     tags = set_test_tags("frappe/frappe-nginx")
@@ -242,6 +257,10 @@ target "erpnext-nginx-stable-test" {
 target "erpnext-worker-stable-test" {
     inherits = ["erpnext-worker-stable"]
     tags = set_test_tags("frappe/erpnext-worker")
+}
+
+group "frappe-stable-test-local" {
+    targets = ["frappe-nginx-stable-test-local", "frappe-worker-stable-test-local", "frappe-socketio-stable-test-local"]
 }
 
 group "frappe-stable-test" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -86,7 +86,7 @@ function "set_localhost_test_tags" {
     result = ["localhost:5000/${repo}:test"]
 }
 
-function "set_default_test_tags" {
+function "set_test_tags" {
     params = [repo]
     result = ["${repo}:test"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -81,9 +81,14 @@ target "test-erpnext-args" {
     }
 }
 
-function "set_test_tags" {
+function "set_localhost_test_tags" {
     params = [repo]
     result = ["localhost:5000/${repo}:test"]
+}
+
+function "set_default_test_tags" {
+    params = [repo]
+    result = ["${repo}:test"]
 }
 
 
@@ -124,6 +129,21 @@ group "erpnext-develop" {
 
 # Test develop images
 
+target "frappe-nginx-develop-test-localhost" {
+    inherits = ["frappe-nginx-develop"]
+    tags = set_localhost_test_tags("frappe/frappe-nginx")
+}
+
+target "frappe-worker-develop-test-localhost" {
+    inherits = ["frappe-worker-develop"]
+    tags = set_localhost_test_tags("frappe/frappe-worker")
+}
+
+target "frappe-socketio-develop-test-localhost" {
+    inherits = ["frappe-socketio-develop"]
+    tags = set_localhost_test_tags("frappe/frappe-socketio")
+}
+
 target "frappe-nginx-develop-test" {
     inherits = ["frappe-nginx-develop"]
     tags = set_test_tags("frappe/frappe-nginx")
@@ -147,6 +167,10 @@ target "erpnext-nginx-develop-test" {
 target "erpnext-worker-develop-test" {
     inherits = ["erpnext-worker-develop", "test-erpnext-args"]
     tags = set_test_tags("frappe/erpnext-worker")
+}
+
+group "frappe-develop-test-localhost" {
+    targets = ["frappe-nginx-develop-test-localhost", "frappe-worker-develop-test-localhost", "frappe-socketio-develop-test-localhost"]
 }
 
 group "frappe-develop-test" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -82,7 +82,7 @@ target "test-erpnext-args" {
 
 function "set_test_tags" {
     params = [repo]
-    result = ["${repo}:test"]
+    result = ["localhost:5000/${repo}:test"]
 }
 
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -77,6 +77,7 @@ function "set_stable_tags" {
 target "test-erpnext-args" {
     args = {
         IMAGE_TAG = "test"
+        DOCKER_REGISTRY_PREFIX = "localhost:5000/frappe"
     }
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -53,6 +53,12 @@ target "stable-args" {
     }
 }
 
+target "test-erpnext-args" {
+    args = {
+        IMAGE_TAG = "test"
+    }
+}
+
 function "set_develop_tags" {
     params = [repo]
     result = ["${repo}:latest", "${repo}:edge", "${repo}:develop"]
@@ -122,12 +128,12 @@ target "frappe-socketio-develop-test" {
 }
 
 target "erpnext-nginx-develop-test" {
-    inherits = ["erpnext-nginx-develop"]
+    inherits = ["erpnext-nginx-develop", "test-erpnext-args"]
     tags = set_test_tags("frappe/erpnext-nginx")
 }
 
 target "erpnext-worker-develop-test" {
-    inherits = ["erpnext-worker-develop"]
+    inherits = ["erpnext-worker-develop", "test-erpnext-args"]
     tags = set_test_tags("frappe/erpnext-worker")
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -250,12 +250,12 @@ target "frappe-socketio-stable-test" {
 }
 
 target "erpnext-nginx-stable-test" {
-    inherits = ["erpnext-nginx-stable"]
+    inherits = ["erpnext-nginx-stable", "test-erpnext-args"]
     tags = set_test_tags("frappe/erpnext-nginx")
 }
 
 target "erpnext-worker-stable-test" {
-    inherits = ["erpnext-worker-stable"]
+    inherits = ["erpnext-worker-stable", "test-erpnext-args"]
     tags = set_test_tags("frappe/erpnext-worker")
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -81,7 +81,7 @@ target "test-erpnext-args" {
     }
 }
 
-function "set_localhost_test_tags" {
+function "set_local_test_tags" {
     params = [repo]
     result = ["localhost:5000/${repo}:test"]
 }
@@ -129,19 +129,19 @@ group "erpnext-develop" {
 
 # Test develop images
 
-target "frappe-nginx-develop-test-localhost" {
+target "frappe-nginx-develop-test-local" {
     inherits = ["frappe-nginx-develop"]
-    tags = set_localhost_test_tags("frappe/frappe-nginx")
+    tags = set_local_test_tags("frappe/frappe-nginx")
 }
 
-target "frappe-worker-develop-test-localhost" {
+target "frappe-worker-develop-test-local" {
     inherits = ["frappe-worker-develop"]
-    tags = set_localhost_test_tags("frappe/frappe-worker")
+    tags = set_local_test_tags("frappe/frappe-worker")
 }
 
-target "frappe-socketio-develop-test-localhost" {
+target "frappe-socketio-develop-test-local" {
     inherits = ["frappe-socketio-develop"]
-    tags = set_localhost_test_tags("frappe/frappe-socketio")
+    tags = set_local_test_tags("frappe/frappe-socketio")
 }
 
 target "frappe-nginx-develop-test" {
@@ -169,8 +169,8 @@ target "erpnext-worker-develop-test" {
     tags = set_test_tags("frappe/erpnext-worker")
 }
 
-group "frappe-develop-test-localhost" {
-    targets = ["frappe-nginx-develop-test-localhost", "frappe-worker-develop-test-localhost", "frappe-socketio-develop-test-localhost"]
+group "frappe-develop-test-local" {
+    targets = ["frappe-nginx-develop-test-local", "frappe-worker-develop-test-local", "frappe-socketio-develop-test-local"]
 }
 
 group "frappe-develop-test" {

--- a/tests/test-erpnext.sh
+++ b/tests/test-erpnext.sh
@@ -22,6 +22,7 @@ docker-compose \
     -f installation/erpnext-publish.yml \
     up -d
 
+print_group Fix permissions
 docker run \
     --rm \
     --user root \

--- a/tests/test-erpnext.sh
+++ b/tests/test-erpnext.sh
@@ -9,15 +9,13 @@ SITE_NAME="test_erpnext.localhost"
 
 echo ::group::Setup env
 cp env-example .env
-sed -i -e "s/FRAPPE_VERSION=edge/FRAPPE_VERSION=$FRAPPE_VERSION/g" .env
-sed -i -e "s/ERPNEXT_VERSION=edge/ERPNEXT_VERSION=test/g" .env
+sed -i -e "s/edge/test/g" .env
 # shellcheck disable=SC2046
 export $(cat .env)
 cat .env
 
 print_group Start services
-FRAPPE_VERSION=$FRAPPE_VERSION ERPNEXT_VERSION="test" \
-    docker-compose \
+docker-compose \
     -p $project_name \
     -f installation/docker-compose-common.yml \
     -f installation/docker-compose-erpnext.yml \

--- a/tests/test-frappe.sh
+++ b/tests/test-frappe.sh
@@ -15,8 +15,7 @@ export $(cat .env)
 cat .env
 
 print_group Start services
-FRAPPE_VERSION="test" \
-    docker-compose \
+docker-compose \
     -p $project_name \
     -f installation/docker-compose-common.yml \
     -f installation/docker-compose-frappe.yml \
@@ -32,4 +31,5 @@ docker run \
     frappe/frappe-worker:test new
 
 ping_site
+docker-compose down
 rm .env

--- a/tests/test-frappe.sh
+++ b/tests/test-frappe.sh
@@ -7,6 +7,16 @@ source tests/functions.sh
 project_name="test_frappe"
 SITE_NAME="test_frappe.localhost"
 
+docker_compose_with_args() {
+    # shellcheck disable=SC2068
+    docker-compose \
+        -p $project_name \
+        -f installation/docker-compose-common.yml \
+        -f installation/docker-compose-frappe.yml \
+        -f installation/frappe-publish.yml \
+        $@
+}
+
 echo ::group::Setup env
 cp env-example .env
 sed -i -e "s/edge/test/g" .env
@@ -15,12 +25,7 @@ export $(cat .env)
 cat .env
 
 print_group Start services
-docker-compose \
-    -p $project_name \
-    -f installation/docker-compose-common.yml \
-    -f installation/docker-compose-frappe.yml \
-    -f installation/frappe-publish.yml \
-    up -d
+docker_compose_with_args up -d
 
 print_group Create site
 docker run \
@@ -31,5 +36,5 @@ docker run \
     frappe/frappe-worker:test new
 
 ping_site
-docker-compose down
+docker_compose_with_args down
 rm .env

--- a/tests/test-frappe.sh
+++ b/tests/test-frappe.sh
@@ -36,5 +36,8 @@ docker run \
     frappe/frappe-worker:test new
 
 ping_site
+
+print_group Stop and remove containers
 docker_compose_with_args down
+
 rm .env


### PR DESCRIPTION
Now our workflows have separate jobs for Frappe and ERPNext. It makes impossible to test and prevent bugs relevant to ERPNext images on PRs. This PR fixes it.

Also:
- brought tests for stable builds back. But now they'll run only on PRs,
- added annotations for `docker-bake.hcl`