### PR TITLE
feat(bench): Skip warnings if envvar BENCH_DEVELOPER set

### DIFF
--- a/build/bench/Dockerfile
+++ b/build/bench/Dockerfile
@@ -92,6 +92,9 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git .pyenv \
 # Clone and install bench in the local user home directory
 # For development, bench source is located in ~/.bench
 ENV PATH /home/frappe/.local/bin:$PATH
+# Skip editable-bench warning
+# https://github.com/frappe/bench/commit/20560c97c4246b2480d7358c722bc9ad13606138
+ENV BENCH_DEVELOPER 1
 RUN git clone ${GIT_REPO} --depth 1 -b ${GIT_BRANCH} .bench \
     && pip install --user -e .bench \
     && echo "export PATH=/home/frappe/.local/bin:\$PATH" >> /home/frappe/.bashrc


### PR DESCRIPTION
Currently bench shows warning about editable mode on every call. version 5.7.0 introduces feature that allows to suppress them.

Before:

<img width="989" alt="Screenshot 2021-11-30 at 12 19 11" src="https://user-images.githubusercontent.com/75225148/144435215-7395e698-edb8-45b1-b150-32f6cb851986.png">

After:

<img width="952" alt="Screenshot 2021-12-02 at 16 53 12" src="https://user-images.githubusercontent.com/75225148/144435240-3f03f0c0-6f0c-4147-b859-9be73fc7570f.png">

Reference: https://github.com/frappe/bench/commit/20560c97c4246b2480d7358c722bc9ad13606138