### PR TITLE
Upgrade mariadb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,12 +139,19 @@ services:
       - redis-socketio-vol:/data
 
   mariadb:
-    image: mariadb:10.3
+    image: mariadb:10.6
     restart: on-failure
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --skip-character-set-client-handshake
+      - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
     environment:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      # Sometimes db initialization takes longer than 10 seconds and site-creator goes away.
+      # Frappe doesn't use CONVERT_TZ() function that requires time zone info, so we can just skip it.
+      - MYSQL_INITDB_SKIP_TZINFO=1
     volumes:
-      - ./installation/frappe-mariadb.cnf:/etc/mysql/conf.d/frappe.cnf
       - mariadb-vol:/var/lib/mysql
 
   site-creator:

--- a/installation/docker-compose-common.yml
+++ b/installation/docker-compose-common.yml
@@ -20,12 +20,19 @@ services:
       - redis-socketio-vol:/data
 
   mariadb:
-    image: mariadb:10.3
+    image: mariadb:10.6
     restart: on-failure
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --skip-character-set-client-handshake
+      - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
     environment:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      # Sometimes db initialization takes longer than 10 seconds and site-creator goes away.
+      # Frappe doesn't use CONVERT_TZ() function that requires time zone info, so we can just skip it.
+      - MYSQL_INITDB_SKIP_TZINFO=1
     volumes:
-      - ./frappe-mariadb.cnf:/etc/mysql/conf.d/frappe.cnf
       - mariadb-vol:/var/lib/mysql
 
 volumes:

--- a/installation/frappe-mariadb.cnf
+++ b/installation/frappe-mariadb.cnf
@@ -1,7 +1,0 @@
-[mysqld]
-character-set-client-handshake = FALSE
-character-set-server = utf8mb4
-collation-server = utf8mb4_unicode_ci
-
-[mysql]
-default-character-set = utf8mb4

--- a/tests/pwd.yml
+++ b/tests/pwd.yml
@@ -151,36 +151,21 @@ services:
     volumes:
       - sites-vol:/sites:rw
 
-  mariadb-configurator:
-    image: mariadb:10.3
-    deploy:
-      restart_policy:
-        condition: none
-    command:
-      - "bash"
-      - "-c"
-      - >
-        echo -e "[mysqld]\n
-        skip-host-cache\n
-        skip-name-resolve\n
-        character-set-client-handshake = FALSE\n
-        character-set-server = utf8mb4\n
-        collation-server = utf8mb4_unicode_ci\n
-        [mysql]\n
-        default-character-set = utf8mb4\n
-        [mysqld_safe]\n
-        skip_log_error\n
-        syslog\n" > /data/frappe.cnf
-    volumes:
-      - mariadb-conf-vol:/data:rw
-
   mariadb:
-    image: mariadb:10.3
+    image: mariadb:10.6
     deploy:
       restart_policy:
         condition: on-failure
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --skip-character-set-client-handshake
+      - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
     environment:
       - MYSQL_ROOT_PASSWORD=admin
+      # Sometimes db initialization takes longer than 10 seconds and site-creator goes away.
+      # Frappe doesn't use CONVERT_TZ() function that requires time zone info, so we can just skip it.
+      - MYSQL_INITDB_SKIP_TZINFO=1
     volumes:
       - mariadb-conf-vol:/etc/mysql/conf.d
       - mariadb-vol:/var/lib/mysql


### PR DESCRIPTION
Upgrade mariadb from 10.3 to 10.6, use `command` parameter in docker-compose files instead of copying mysql config file.
This works fine for me in production for a while.

@revant Couple of questions.
1. How do you feel about inline db configuration?
2. Will this break Try in Play With Docker config?

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
