### PR TITLE
fix(bench): Set `BENCH_DEVELOPER` env var in bashrc instead of Dockerfile

### DIFF
--- a/build/bench/Dockerfile
+++ b/build/bench/Dockerfile
@@ -94,10 +94,10 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git .pyenv \
 ENV PATH /home/frappe/.local/bin:$PATH
 # Skip editable-bench warning
 # https://github.com/frappe/bench/commit/20560c97c4246b2480d7358c722bc9ad13606138
-ENV BENCH_DEVELOPER 1
 RUN git clone ${GIT_REPO} --depth 1 -b ${GIT_BRANCH} .bench \
     && pip install --user -e .bench \
-    && echo "export PATH=/home/frappe/.local/bin:\$PATH" >> /home/frappe/.bashrc
+    && echo "export PATH=/home/frappe/.local/bin:\$PATH" >>/home/frappe/.bashrc \
+    && echo "export BENCH_DEVELOPER=1" >>/home/frappe/.bashrc
 
 # Install Node via nvm
 ENV NODE_VERSION=14.18.1


### PR DESCRIPTION
I'm not sure why it worked in previous PR (https://github.com/frappe/frappe_docker/pull/593#issue-1069573878) 🤔 Not it certainly should work.
