### PR TITLE
fix: Remove `--log.level=DEBUG` from traefik command to reduce log verbosity

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   traefik:
     image: "traefik:v2.2"
     command:
-      - "--log.level=DEBUG"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.web.address=:80"

--- a/installation/frappe-postgresql/docker-compose.yml
+++ b/installation/frappe-postgresql/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   traefik:
     image: "traefik:v2.2"
     command:
-      - "--log.level=DEBUG"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.web.address=:80"

--- a/tests/pwd.yml
+++ b/tests/pwd.yml
@@ -11,7 +11,6 @@ services:
       labels:
         - "traefik.enable=true"
     command:
-      - "--log.level=DEBUG"
       - "--providers.docker"
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.web.address=:80"


### PR DESCRIPTION
80% of logs come from `traefik` and they are not that useful.