### PR TITLE
Update settings.json

### DIFF
--- a/development/vscode-example/settings.json
+++ b/development/vscode-example/settings.json
@@ -1,3 +1,7 @@
 {
-  "debug.node.autoAttach": "disabled"
+  "debug.node.autoAttach": "disabled",
+  "python.pythonPath": "/workspace/frappe-bench/env/bin/python",
+  "python.analysis.extraPaths": [
+    "./frappe-bench/apps/frappe"
+  ],
 }


### PR DESCRIPTION
removes a squiggly line whenever doing imports like 
```
from frappe.model.document import Document
```

> Please provide enough information so that others can review your pull request:

Whenever I work on frappe bench inside devcontainer, inside all doctypes I didn't get proper type completion and squiggly lines. This fixes it.

> Explain the **details** for making this change. What existing problem does the pull request solve?

Removes warnings from pylance
