### PR TITLE
Change mysql.user table to mysql.global_priv table for MariaDB 10.4+

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -276,7 +276,7 @@ mysql -uroot -p123 -hmariadb
 Execute following queries replacing `db_name` and `db_password` with the values found in site_config.json.
 
 ```sql
-UPDATE mysql.user SET Host = '%' where User = 'db_name'; FLUSH PRIVILEGES;
+UPDATE mysql.global_priv SET Host = '%' where User = 'db_name'; FLUSH PRIVILEGES;
 SET PASSWORD FOR 'db_name'@'%' = PASSWORD('db_password'); FLUSH PRIVILEGES;
 GRANT ALL PRIVILEGES ON `db_name`.* TO 'db_name'@'%'; FLUSH PRIVILEGES;
 EXIT;


### PR DESCRIPTION
Since frappe_docker now uses the mariadb:10.6 docker image for its database, the `UPDATE mysql.user SET Host = '%' where User = 'db_name'; FLUSH PRIVILEGES;` command fails as _mysql.user_ is deprecated and is now a view to the _mysql.global_priv_ table as from MariaDB 10.4+: [https://mariadb.com/kb/en/mysqluser-table/](url).