### PR TITLE
fix: check if s3 object is a directory by checking the start of the object `ContentType` property

### DIFF
--- a/build/frappe-worker/commands/push_backup.py
+++ b/build/frappe-worker/commands/push_backup.py
@@ -75,7 +75,7 @@ def delete_old_backups(limit, bucket, site_name):
         for obj in objects.get("CommonPrefixes"):
             if obj.get("Prefix") == bucket_dir + "/":
                 for backup_obj in bucket.objects.filter(Prefix=obj.get("Prefix")):
-                    if backup_obj.get()["ContentType"] == "application/x-directory":
+                    if backup_obj.get()["ContentType"].startswith("application/x-directory"):
                         continue
                     try:
                         # backup_obj.key is bucket_dir/site/date_time/backupfile.extension


### PR DESCRIPTION

> Please provide enough information so that others can review your pull request:

After uploading the backups. and checking for the local files to download, `push_backup.py` specifically `delete_old_backups` method assumes that S3 objects that are actually directories will be only marked as `application/x-directory` in the `ContentType` object property. But there are some cases -like mine- that has more information such us: `application/x-directory; charset=UTF-8`.

This fix only changes the `ContentType` check by using `startswith()`

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
