### PR TITLE
fix: new site command on Frappe >13.21.0

### DIFF
--- a/build/frappe-worker/commands/new.py
+++ b/build/frappe-worker/commands/new.py
@@ -62,8 +62,8 @@ def main():
         _new_site(
             None,
             site_name,
-            mariadb_root_username=db_root_username,
-            mariadb_root_password=db_root_password,
+            db_root_username,
+            db_root_password,
             admin_password=get_password("ADMIN_PASSWORD", "admin"),
             verbose=True,
             install_apps=install_apps,


### PR DESCRIPTION
After https://github.com/frappe/frappe/pull/16134
`TypeError: _new_site() got an unexpected keyword argument 'mariadb_root_username'`