### PR TITLE
Fix configurator command on some platforms

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,7 @@ x-backend-defaults: &backend_defaults
 services:
   configurator:
     <<: *backend_defaults
-    command: configure.py
+    command: /usr/local/bin/configure.py
     environment:
       DB_HOST: ${DB_HOST}
       DB_PORT: ${DB_PORT}


### PR DESCRIPTION
Turns out _on some machines_ `configurator` serivce fails because of path resolving (I guess that's why). I encountered this error when debugging custom app Docker setup in GitHub Actions. Also https://github.com/vrslev/frappe_docker/pull/26
