### PR TITLE
fix: add entrypoint to worker

### DIFF
--- a/images/worker/Dockerfile
+++ b/images/worker/Dockerfile
@@ -114,13 +114,13 @@ CMD [ "/home/frappe/frappe-bench/env/bin/gunicorn", "-b", "0.0.0.0:8000", "frapp
 FROM configured_base as frappe
 
 RUN echo "frappe" >/home/frappe/frappe-bench/sites/apps.txt
-COPY --from=frappe_builder /home/frappe/frappe-bench/apps/frappe /home/frappe/frappe-bench/apps/frappe
-COPY --from=frappe_builder /home/frappe/frappe-bench/env /home/frappe/frappe-bench/env
+COPY --from=frappe_builder --chown=frappe:frappe /home/frappe/frappe-bench/apps/frappe /home/frappe/frappe-bench/apps/frappe
+COPY --from=frappe_builder --chown=frappe:frappe /home/frappe/frappe-bench/env /home/frappe/frappe-bench/env
 
 
 FROM configured_base as erpnext
 
 RUN echo "frappe\nerpnext" >/home/frappe/frappe-bench/sites/apps.txt
-COPY --from=frappe_builder /home/frappe/frappe-bench/apps/frappe /home/frappe/frappe-bench/apps/frappe
-COPY --from=erpnext_builder /home/frappe/frappe-bench/apps/erpnext /home/frappe/frappe-bench/apps/erpnext
-COPY --from=erpnext_builder /home/frappe/frappe-bench/env /home/frappe/frappe-bench/env
+COPY --from=frappe_builder --chown=frappe:frappe /home/frappe/frappe-bench/apps/frappe /home/frappe/frappe-bench/apps/frappe
+COPY --from=erpnext_builder --chown=frappe:frappe /home/frappe/frappe-bench/apps/erpnext /home/frappe/frappe-bench/apps/erpnext
+COPY --from=erpnext_builder --chown=frappe:frappe /home/frappe/frappe-bench/env /home/frappe/frappe-bench/env

--- a/images/worker/Dockerfile
+++ b/images/worker/Dockerfile
@@ -102,8 +102,11 @@ COPY pretend-bench.sh /usr/local/bin/bench
 COPY push_backup.py /usr/local/bin/push-backup
 COPY configure.py patched_bench_helper.py /usr/local/bin/
 COPY gevent_patch.py /opt/patches/
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
 WORKDIR /home/frappe/frappe-bench/sites
+
+ENTRYPOINT [ "entrypoint.sh" ]
 
 CMD [ "/home/frappe/frappe-bench/env/bin/gunicorn", "-b", "0.0.0.0:8000", "frappe.app:application" ]
 

--- a/images/worker/Dockerfile
+++ b/images/worker/Dockerfile
@@ -106,7 +106,7 @@ COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
 WORKDIR /home/frappe/frappe-bench/sites
 
-ENTRYPOINT [ "entrypoint.sh" ]
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
 
 CMD [ "/home/frappe/frappe-bench/env/bin/gunicorn", "-b", "0.0.0.0:8000", "frappe.app:application" ]
 

--- a/images/worker/entrypoint.sh
+++ b/images/worker/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# Link Frappe's node_modules/ to make Website Theme work
+if test -d /home/frappe/frappe-bench/sites/assets/frappe/node_modules; then
+  ln -sfn /home/frappe/frappe-bench/sites/assets/frappe/node_modules /home/frappe/frappe-bench/apps/frappe/node_modules
+fi
+
+exec "$@"


### PR DESCRIPTION
symlinks frappe node_modules from sites/assets to apps/frappe

#695