### PR TITLE
Update docs to advise for docker-compose v2

### DIFF
--- a/docs/images-and-compose-files.md
+++ b/docs/images-and-compose-files.md
@@ -51,6 +51,8 @@ It is quite simple to run overrides. All we need to do is to specify compose fil
 docker-compose -f compose.yaml -f overrides/compose.erpnext.yaml config
 ```
 
+⚠ Make sure to use docker-compose v2 (run `docker-compose -v` to check). If you want to use v1 make sure the correct `$`-signs as they get duplicated by the `config` command!
+
 That's it! Of course, we also have to setup `.env` before all of that, but that's not the point.
 
 ## Configuration


### PR DESCRIPTION
This change is to inform users to use docker-compose v2. Using v1 can cause problems when parsing the final docker-compose.yaml. Fixes? #701

> Explain the **details** for making this change. What existing problem does the pull request solve?
Expands the documentation to warn users using docker-compose v1.
