### PR TITLE
Fix example.env workflow failures

### DIFF
--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -86,6 +86,7 @@ jobs:
           else
             echo "example.env changed, pushing changes..."
             git commit -m "chore: Update example.env"
+            git pull --rebase
             git push origin main
           fi
 


### PR DESCRIPTION
It failed when Frappe and ERPNext both released new versions. Now it shouldn't fail. To be sure, we need to test it in production.