### PR TITLE
Fix develop build

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-frappe @ git+git://github.com/frappe/frappe.git
+frappe @ git+https://github.com/frappe/frappe.git
 boto3-stubs[s3]
 black==22.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,17 +10,16 @@ from tests.utils import CI, Compose
 
 
 def _add_version_var(name: str, env_path: Path):
-    if not os.getenv(name):
+    value = os.getenv(name)
+
+    if not value:
         return
 
-    if (gh_env := os.getenv("GITHUB_ENV")) and os.environ[name] == "develop":
-        with open(gh_env, "a") as f:
-            f.write(f"\n{name}=latest")
-
-        os.environ[name] = "latest"
+    if value == "develop":
+        value = "latest"
 
     with open(env_path, "a") as f:
-        f.write(f"\n{name}={os.environ[name]}")
+        f.write(f"\n{name}={value}")
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,10 +16,10 @@ def _add_version_var(name: str, env_path: Path):
         return
 
     if value == "develop":
-        value = "latest"
+        os.environ[name] = "latest"
 
     with open(env_path, "a") as f:
-        f.write(f"\n{name}={value}")
+        f.write(f"\n{name}={os.environ[name]}")
 
 
 @pytest.fixture(scope="session")
@@ -31,7 +31,7 @@ def env_file(tmp_path_factory: pytest.TempPathFactory):
     for var in ("FRAPPE_VERSION", "ERPNEXT_VERSION"):
         _add_version_var(name=var, env_path=file_path)
 
-    yield file_path
+    yield str(file_path)
     os.remove(file_path)
 
 


### PR DESCRIPTION
Prevent tests from modifying $GITHUB_ENV. Also updated Frappe Git URL (git -> https): pip fails to install using git protocol for some reason.

#722