### PR TITLE
Remove git reference from install-app

### DIFF
--- a/custom_app/README.md
+++ b/custom_app/README.md
@@ -41,4 +41,6 @@ Cool! You just containerized your app!
 
 ## Installing multiple apps
 
-Both backend and frontend builds contain `install-app` script that places app where it should be. Each call to script installs given app. Usage: `install-app [APP_NAME] [BRANCH?] [GIT_URL?]`.
+Both backend and frontend builds contain `install-app` script that places app where it should be. Each call to script installs given app. Usage: `install-app [APP_NAME]`.
+
+If you want to install an app from git, clone it locally, COPY in Dockerfile.

--- a/custom_app/backend.Dockerfile
+++ b/custom_app/backend.Dockerfile
@@ -11,10 +11,4 @@ COPY . ../apps/${APP_NAME}
 RUN --mount=type=cache,target=/root/.cache/pip \
     install-app ${APP_NAME}
 
-# or with git:
-# ARG APP_NAME
-# ARG BRANCH
-# ARG GIT_URL
-# RUN install-assets ${APP_NAME} ${BRANCH} ${GIT_URL}
-
 USER frappe

--- a/custom_app/frontend.Dockerfile
+++ b/custom_app/frontend.Dockerfile
@@ -7,12 +7,6 @@ ARG APP_NAME
 COPY . apps/${APP_NAME}
 RUN install-app ${APP_NAME}
 
-# or with git:
-# ARG APP_NAME
-# ARG BRANCH
-# ARG GIT_URL
-# RUN install-app ${APP_NAME} ${BRANCH} ${GIT_URL}
-
 
 FROM frappe/erpnext-nginx:${ERPNEXT_VERSION}
 

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -14,10 +14,9 @@ RUN mkdir -p sites/assets /out/assets \
     && echo frappe >sites/apps.txt
 
 ARG FRAPPE_VERSION
-RUN git clone --depth 1 -b ${FRAPPE_VERSION} https://github.com/frappe/frappe apps/frappe
-
 # Install development node modules
-RUN yarn --cwd apps/frappe \
+RUN git clone --depth 1 -b ${FRAPPE_VERSION} https://github.com/frappe/frappe apps/frappe \
+    && yarn --cwd apps/frappe \
     # TODO: Currently `yarn run production` doesn't create .build on develop branch: https://github.com/frappe/frappe/issues/15396
     && if [ ! -f sites/.build ]; then touch sites/.build; fi \
     && cp sites/.build /out
@@ -33,7 +32,8 @@ RUN install-app frappe
 FROM assets_builder as erpnext_assets
 
 ARG ERPNEXT_VERSION
-RUN install-app erpnext ${ERPNEXT_VERSION} https://github.com/frappe/erpnext
+RUN git clone --depth 1 -b ${ERPNEXT_VERSION} https://github.com/frappe/erpnext apps/erpnext \
+    && install-app erpnext
 
 
 FROM alpine/git as bench

--- a/images/nginx/install-app.sh
+++ b/images/nginx/install-app.sh
@@ -2,14 +2,9 @@
 set -e
 set -x
 
-APP=$1 BRANCH=$2 GIT_URL=$3
+APP=$1
 
 cd /frappe-bench
-
-if test "$BRANCH" && test "$GIT_URL"; then
-  # Clone in case not copied manually
-  git clone --depth 1 -b "$BRANCH" "$GIT_URL" "apps/$APP"
-fi
 
 # Add all not built assets
 cp -r "apps/$APP/$APP/public" "/out/assets/$APP"
@@ -26,4 +21,4 @@ cp -r sites/assets /out
 
 # Cleanup
 rm -rf "apps/$APP"
-rm -rf sites/assets
+rm -rf sites/assets/*

--- a/images/nginx/install-app.sh
+++ b/images/nginx/install-app.sh
@@ -4,7 +4,17 @@ set -x
 
 APP=$1
 
+cleanup() {
+  rm -rf "apps/$APP"
+  rm -rf sites/assets/*
+}
+
 cd /frappe-bench
+
+if ! test -d "apps/$APP/$APP/public"; then
+  cleanup
+  exit 0
+fi
 
 # Add all not built assets
 cp -r "apps/$APP/$APP/public" "/out/assets/$APP"
@@ -19,6 +29,4 @@ echo "$APP" >>sites/apps.txt
 yarn --cwd apps/frappe run production --app "$APP"
 cp -r sites/assets /out
 
-# Cleanup
-rm -rf "apps/$APP"
-rm -rf sites/assets/*
+cleanup

--- a/images/worker/Dockerfile
+++ b/images/worker/Dockerfile
@@ -43,7 +43,8 @@ FROM build_deps as frappe_builder
 
 ARG FRAPPE_VERSION
 RUN --mount=type=cache,target=/root/.cache/pip \
-    install-app frappe ${FRAPPE_VERSION} https://github.com/frappe/frappe \
+    git clone --depth 1 -b ${FRAPPE_VERSION} https://github.com/frappe/frappe apps/frappe \
+    && install-app frappe \
     && env/bin/pip install -U gevent \
     # Link Frappe's node_modules/ to make Website Theme work
     && mkdir -p /home/frappe/frappe-bench/sites/assets/frappe/node_modules \
@@ -54,7 +55,8 @@ FROM frappe_builder as erpnext_builder
 
 ARG ERPNEXT_VERSION
 RUN --mount=type=cache,target=/root/.cache/pip \
-    install-app erpnext ${ERPNEXT_VERSION} https://github.com/frappe/erpnext
+    git clone --depth 1 -b ${ERPNEXT_VERSION} https://github.com/frappe/erpnext apps/erpnext \
+    && install-app erpnext
 
 
 FROM base as configured_base

--- a/images/worker/install-app.sh
+++ b/images/worker/install-app.sh
@@ -2,15 +2,11 @@
 set -e
 set -x
 
-APP=$1 BRANCH=$2 GIT_URL=$3
+APP=$1
 
 cd /home/frappe/frappe-bench
 
-if test "$BRANCH" && test "$GIT_URL"; then
-  # Clone in case not copied manually
-  git clone --depth 1 -b "$BRANCH" "$GIT_URL" "apps/$APP"
-  rm -r "apps/$APP/.git"
-fi
+rm -rf "apps/$APP/.git"
 
 env/bin/pip install -e "apps/$APP"
 


### PR DESCRIPTION
Before, custom app builders could install apps from Git, this prevents it. Issue was that final backend images (frappe and erpnext) didn't have Git installed. In #735 we decided that we should keep Git out of the backend image.

In this PR:
- Remove Git reference from install-app scripts, update Dockerfiles accordingly
- Update custom app guide
- Fix issue with missing sites/assets folder

Fixes #735.
