### PR TITLE
feat: add PWD button

### DIFF
--- a/.github/scripts/update_pwd.py
+++ b/.github/scripts/update_pwd.py
@@ -1,0 +1,33 @@
+import os
+import re
+
+
+def get_versions():
+    frappe_version = os.getenv("FRAPPE_VERSION")
+    erpnext_version = os.getenv("ERPNEXT_VERSION")
+    assert frappe_version, "No Frappe version set"
+    assert erpnext_version, "No ERPNext version set"
+    return frappe_version, erpnext_version
+
+
+def update_pwd(frappe_version: str, erpnext_version: str):
+    with open("pwd.yml", "r+") as f:
+        content = f.read()
+        for image, version in (
+            ("frappe/frappe-socketio", frappe_version),
+            ("frappe/erpnext-worker", erpnext_version),
+            ("frappe/erpnext-nginx", erpnext_version),
+        ):
+            content = re.sub(rf"{image}:.*", f"{image}:{version}", content)
+        f.seek(0)
+        f.truncate()
+        f.write(content)
+
+
+def main() -> int:
+    update_pwd(*get_versions())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -56,8 +56,8 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  update_example_env:
-    name: Update example.env
+  update_versions:
+    name: Update example.env and pwd.yml
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'frappe/frappe_docker' && github.event_name != 'pull_request' }}
     needs: v13

--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -75,18 +75,20 @@ jobs:
         run: python3 ./.github/scripts/get_latest_tags.py --repo erpnext --version 13
 
       - name: Update
-        run: python3 ./.github/scripts/update_example_env.py
+        run: |
+          python3 ./.github/scripts/update_example_env.py
+          python3 ./.github/scripts/update_pwd.py
 
       - name: Push
         run: |
           git config --global user.name github-actions
           git config --global user.email github-actions@github.com
-          git add example.env
+          git add example.env pwd.yml
           if [ -z "$(git status --porcelain)" ]; then
-            echo "example.env did not change, exiting."
+            echo "versions did not change, exiting."
             exit 0
           else
-            echo "example.env changed, pushing changes..."
+            echo "version changed, pushing changes..."
             git commit -m "chore: Update example.env"
             git pull --rebase
             git push origin main

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ git clone https://github.com/frappe/frappe_docker
 cd frappe_docker
 ```
 
+### Try in Play With Docker
+
+<a href="https://labs.play-with-docker.com/?stack=https://raw.githubusercontent.com/frappe/frappe_docker/main/pwd.yml">
+  <img src="https://raw.githubusercontent.com/play-with-docker/stacks/master/assets/images/button.png" alt="Try in PWD"/>
+</a>
+
+Wait for 5 minutes for ERPNext site to be created or check `create-site` container logs before opening browser on port 8080. (username: `Administrator`, password: `admin`)
+
 # Development
 
 We have baseline for developing in VSCode devcontainer with [frappe/bench](https://github.com/frappe/bench). [Start development](development).

--- a/pwd.yml
+++ b/pwd.yml
@@ -1,0 +1,164 @@
+version: "3"
+
+services:
+  backend:
+    image: frappe/erpnext-worker:v13.24.0
+    deploy:
+      restart_policy:
+        condition: on-failure
+    volumes:
+      - sites:/home/frappe/frappe-bench/sites
+      - assets:/home/frappe/frappe-bench/sites/assets
+
+  configurator:
+    image: frappe/erpnext-worker:v13.24.0
+    command:
+      - configure.py
+    environment:
+      DB_HOST: db
+      DB_PORT: "3306"
+      REDIS_CACHE: redis:6379/0
+      REDIS_QUEUE: redis:6379/1
+      REDIS_SOCKETIO: redis:6379/2
+      SOCKETIO_PORT: "9000"
+    volumes:
+      - sites:/home/frappe/frappe-bench/sites
+
+  create-site:
+    image: frappe/erpnext-worker:v13.24.0
+    deploy:
+      restart_policy:
+        condition: on-failure
+    volumes:
+      - sites:/home/frappe/frappe-bench/sites
+      - assets:/home/frappe/frappe-bench/sites/assets
+    entrypoint:
+      - bash
+      - -c
+    command:
+      - >
+        wait-for-it -t 120 db:3306;
+        wait-for-it -t 120 redis:6379;
+        export start=`date +%s`;
+        until [[ -n `grep -hs ^ common_site_config.json | jq -r ".db_host // empty"` ]] && \
+          [[ -n `grep -hs ^ common_site_config.json | jq -r ".redis_cache // empty"` ]] && \
+          [[ -n `grep -hs ^ common_site_config.json | jq -r ".redis_queue // empty"` ]];
+        do
+          echo "Waiting for common_site_config.json to be created";
+          sleep 5;
+          if (( `date +%s`-start > 120 )); then
+            echo "could not find common_site_config.json with required keys";
+            exit 1
+          fi
+        done;
+        echo "common_site_config.json found";
+        bench new-site frontend --admin-password=admin --db-root-password=admin --install-app erpnext --set-default;
+
+  db:
+    image: mariadb:10.6
+    healthcheck:
+      test: mysqladmin ping -h localhost --password=admin
+      interval: 1s
+      retries: 15
+    deploy:
+      restart_policy:
+        condition: on-failure
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --skip-character-set-client-handshake
+      - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
+    environment:
+      MYSQL_ROOT_PASSWORD: admin
+    volumes:
+      - db-data:/var/lib/mysql
+
+  frontend:
+    image: frappe/erpnext-nginx:v13.24.0
+    deploy:
+      restart_policy:
+        condition: on-failure
+    environment:
+      BACKEND: backend:8000
+      FRAPPE_SITE_NAME_HEADER: frontend
+      SOCKETIO: websocket:9000
+      UPSTREAM_REAL_IP_ADDRESS: 127.0.0.1
+      UPSTREAM_REAL_IP_HEADER: X-Forwarded-For
+      UPSTREAM_REAL_IP_RECURSIVE: "off"
+    volumes:
+      - sites:/home/frappe/frappe-bench/sites
+      - assets:/home/frappe/frappe-bench/sites/assets
+    ports:
+      - "8080:8080"
+
+  queue-default:
+    image: frappe/erpnext-worker:v13.24.0
+    deploy:
+      restart_policy:
+        condition: on-failure
+    command:
+      - bench
+      - worker
+      - --queue
+      - default
+    volumes:
+      - sites:/home/frappe/frappe-bench/sites
+
+  queue-long:
+    image: frappe/erpnext-worker:v13.24.0
+    deploy:
+      restart_policy:
+        condition: on-failure
+    command:
+      - bench
+      - worker
+      - --queue
+      - long
+    volumes:
+      - sites:/home/frappe/frappe-bench/sites
+
+  queue-short:
+    image: frappe/erpnext-worker:v13.24.0
+    deploy:
+      restart_policy:
+        condition: on-failure
+    command:
+      - bench
+      - worker
+      - --queue
+      - short
+    volumes:
+      - sites:/home/frappe/frappe-bench/sites
+
+  redis:
+    image: redis:6.2-alpine
+    deploy:
+      restart_policy:
+        condition: on-failure
+    volumes:
+      - redis-data:/data
+
+  scheduler:
+    image: frappe/erpnext-worker:v13.24.0
+    deploy:
+      restart_policy:
+        condition: on-failure
+    command:
+      - bench
+      - schedule
+    volumes:
+      - sites:/home/frappe/frappe-bench/sites
+
+  websocket:
+    image: frappe/frappe-socketio:v13.24.0
+    deploy:
+      restart_policy:
+        condition: on-failure
+    volumes:
+      - sites:/home/frappe/frappe-bench/sites
+
+volumes:
+  assets:
+  db-data:
+  redis-data:
+  sites:


### PR DESCRIPTION
- add pwd button in readme
- add workflow to update pwd.yml

Test:

<a href="https://labs.play-with-docker.com/?stack=https://raw.githubusercontent.com/revant/frappe_docker/pwd/pwd.yml">
  <img src="https://raw.githubusercontent.com/play-with-docker/stacks/master/assets/images/button.png" alt="Try in PWD"/>
</a>

Wait for 5 minutes for ERPNext site to be created or check `create-site` container logs before opening browser on port 8080. (username: `Administrator`, password: `admin`)
