### PR TITLE
fix: unable to log into Traefik dashboard

### DIFF
--- a/docs/single-server-example.md
+++ b/docs/single-server-example.md
@@ -65,7 +65,7 @@ Create a file called `traefik.env` in `~/gitops`
 ```shell
 echo 'TRAEFIK_DOMAIN=traefik.example.com' > ~/gitops/traefik.env
 echo 'EMAIL=admin@example.com' >> ~/gitops/traefik.env
-echo 'HASHED_PASSWORD='$(openssl passwd -apr1 changeit | sed 's/\$/\\\$/g') >> ~/gitops/traefik.env
+echo 'HASHED_PASSWORD='$(openssl passwd -apr1 changeit) >> ~/gitops/traefik.env
 ```
 
 Note:


### PR DESCRIPTION
### Please provide enough information so that others can review your pull request:

It was not allow to log into Traefik dashboard

### Explain the **details** for making this change. What existing problem does the pull request solve?

The pipelined sed command `sed 's/\$/\\\$/g'` makes $ escaped but docker compose or Traefik doesn't understand it. I can't login into Traefik dashboard without remove the pipelined sed command.
