### PR TITLE
ci: do not build arm64 images for v13

### DIFF
--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -51,7 +51,7 @@ jobs:
       repo: erpnext
       version: "13"
       push: ${{ github.repository == 'frappe/frappe_docker' && github.event_name != 'pull_request' }}
-      platforms: linux/amd64,linux/arm64
+      platforms: linux/amd64
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
All other builds seems to be built fast.