### PR TITLE
Add the base URL to the rewrite rules in the nginx config template

### DIFF
--- a/images/nginx/nginx-template.conf
+++ b/images/nginx/nginx-template.conf
@@ -54,9 +54,9 @@ server {
 	}
 
 	location / {
- 		rewrite ^(.+)/$ $1 permanent;
-  		rewrite ^(.+)/index\.html$ $1 permanent;
-  		rewrite ^(.+)\.html$ $1 permanent;
+		rewrite ^(.+)/$ https://$http_host$1 permanent;
+		rewrite ^(.+)/index\.html$ https://$http_host$1 permanent;
+		rewrite ^(.+)\.html$ https://$http_host$1 permanent;
 
 		location ~ ^/files/.*.(htm|html|svg|xml) {
 			add_header Content-disposition "attachment";


### PR DESCRIPTION
When visiting an ERPNext URL with a trailing slash like `https://erp.mydomain.com/app/`, it redirects to an invalid URL `https://erp.mydomain.com:8080/app`.

This happens because the nginx rewrite rule in the configuration template does not specify a base URL for the target. This pull request will fix the invalid redirects.