### PR TITLE
ci: bypass docker compose stop failure

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,7 +46,11 @@ class Compose:
             self("exec", "-T", *cmd)
 
     def stop(self) -> None:
-        subprocess.check_call(self.base_cmd + ("down", "-v", "--remove-orphans"))
+        try:
+            subprocess.check_call(self.base_cmd + ("down", "-v", "--remove-orphans"))
+        except subprocess.CalledProcessError as e:
+            print("docker compose stop command failed")
+            print(e)
 
     def bench(self, *cmd: str) -> None:
         self.exec("backend", "bench", *cmd)


### PR DESCRIPTION
docker compose stop without starting the project
results in failure. Bypass the exception for
docker compose stop