### PR TITLE
Fixed a mistake in app installation command.

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -173,14 +173,14 @@ To install custom app
 
 ```shell
 # --branch is optional, use it to point to branch on custom app repository
-bench get --branch version-12 https://github.com/myusername/myapp
+bench get-app --branch version-12 https://github.com/myusername/myapp
 bench --site mysite.localhost install-app myapp
 ```
 
-To install ERPNext (from the version-12 branch):
+To install ERPNext (from the version-13 branch):
 
 ```shell
-bench get --branch version-12 erpnext
+bench get-app --branch version-13 erpnext
 bench --site mysite.localhost install-app erpnext
 ```
 


### PR DESCRIPTION
- In the app installation step, the provided command was wrong. 
- The command has been fixed.
- I also changed the example command to use version 13 of ERPNext instead of 12, as most will be working on v13.
