### PR TITLE
Update Dockerfile

### DIFF
--- a/images/socketio/Dockerfile
+++ b/images/socketio/Dockerfile
@@ -14,8 +14,8 @@ USER frappe
 WORKDIR /home/frappe/frappe-bench
 RUN mkdir -p sites apps/frappe
 
-COPY --from=builder /opt/frappe/socketio.js /opt/frappe/node_utils.js apps/frappe/
-COPY package.json apps/frappe/
+COPY --chown=frappe:frappe --from=builder /opt/frappe/socketio.js /opt/frappe/node_utils.js apps/frappe/
+COPY --chown=frappe:frappe package.json apps/frappe/
 
 RUN cd apps/frappe \
     && npm install


### PR DESCRIPTION
Changing user to frappe makes all after commands make executable under frappe user except COPY command so trying with externally specifying with --chown=frappe:frappe

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Why am I getting this error ?





```
=> CACHED [frappe-socketio stage-1 2/8] RUN addgroup -  0.0s
 => CACHED [frappe-socketio stage-1 3/8] WORKDIR /home/  0.0s
 => CACHED [frappe-socketio stage-1 4/8] RUN mkdir -p s  0.0s
 => CACHED [frappe-socketio builder 2/2] RUN git clone   0.0s
 => CACHED [frappe-socketio stage-1 5/8] COPY --from=bu  0.0s
 => CACHED [frappe-socketio stage-1 6/8] COPY package.j  0.0s
 => ERROR [frappe-socketio stage-1 7/8] RUN cd apps/fra  2.4s
 => CACHED [frappe-worker] docker-image://docker.io/doc  0.0s
 => CACHED [erpnext-nginx assets_builder 1/6] FROM dock  0.0s
 => [assets-builder internal] load build context         0.0s
 => => transferring context: 105B                        0.0s
 => CANCELED [assets-builder assets_builder 2/6] RUN ap  2.5s
 => [frappe-nginx internal] load build context           0.0s
 => => transferring context: 315B                        0.0s
 => [erpnext-nginx frappe 1/5] FROM docker.io/nginxinc/  0.0s
 => [erpnext-nginx internal] load build context          0.0s
 => => transferring context: 315B                        0.0s
 => [erpnext-worker internal] load build definition fro  0.0s
 => [erpnext-worker internal] load .dockerignore         0.0s
 => CANCELED [frappe-worker internal] load metadata for  1.2s
 => [frappe-worker internal] load .dockerignore          0.0s
 => [frappe-worker internal] load build definition from  0.0s
------
 > [frappe-socketio stage-1 7/8] RUN cd apps/frappe && npm install:
#0 2.105 npm ERR! code EACCES
#0 2.106 npm ERR! syscall open
#0 2.108 npm ERR! path /home/frappe/frappe-bench/apps/frappe/package.json
#0 2.108 npm ERR! errno -13
#0 2.111 npm ERR! Error: EACCES: permission denied, open '/home/frappe/frappe-bench/apps/frappe/package.json'
#0 2.111 npm ERR!  [Error: EACCES: permission denied, open '/home/frappe/frappe-bench/apps/frappe/package.json'] {
#0 2.111 npm ERR!   errno: -13,
#0 2.111 npm ERR!   code: 'EACCES',
#0 2.112 npm ERR!   syscall: 'open',
#0 2.112 npm ERR!   path: '/home/frappe/frappe-bench/apps/frappe/package.json'
#0 2.112 npm ERR! }
#0 2.112 npm ERR!
#0 2.112 npm ERR! The operation was rejected by your operating system.
#0 2.112 npm ERR! It is likely you do not have the permissions to access this file as the current user
#0 2.112 npm ERR!
#0 2.112 npm ERR! If you believe this might be a permissions issue, please double-check the
#0 2.112 npm ERR! permissions of the file and its containing directories, or try running
#0 2.112 npm ERR! the command again as root/Administrator.
#0 2.114
#0 2.114 npm ERR! A complete log of this run can be found in:
#0 2.114 npm ERR!     /home/frappe/.npm/_logs/2022-06-24T02_50_00_579Z-debug-0.log
------
error: failed to solve: executor failed running [/bin/sh -c cd apps/frappe && npm install]: exit code: 243
```