### PR TITLE
Fix for multiple simultaneous running stacks

### DIFF
--- a/docs/compose/compose.multi-bench.yaml
+++ b/docs/compose/compose.multi-bench.yaml
@@ -13,6 +13,7 @@ services:
   configurator:
     networks:
       - bench-network
+      - mariadb-network
   backend:
     networks:
       - mariadb-network
@@ -20,21 +21,26 @@ services:
   websocket:
     networks:
       - bench-network
+      - mariadb-network
   scheduler:
     networks:
       - bench-network
+      - mariadb-network
   queue-default:
     networks:
       - bench-network
+      - mariadb-network
   queue-short:
     networks:
       - bench-network
   queue-long:
     networks:
       - bench-network
+      - mariadb-network
   redis:
     networks:
       - bench-network
+      - mariadb-network
 
 networks:
   traefik-public:

--- a/docs/compose/compose.multi-bench.yaml
+++ b/docs/compose/compose.multi-bench.yaml
@@ -2,7 +2,6 @@ services:
   frontend:
     networks:
       - traefik-public
-      - mariadb-network
       - bench-network
     labels:
       - traefik.enable=true
@@ -16,6 +15,7 @@ services:
       - bench-network
   backend:
     networks:
+      - mariadb-network
       - bench-network
   websocket:
     networks:

--- a/docs/compose/compose.multi-bench.yaml
+++ b/docs/compose/compose.multi-bench.yaml
@@ -13,28 +13,28 @@ services:
       - traefik.http.routers.${ROUTER}-http.rule=Host(${SITES?SITES not set})
   configurator:
     networks:
-      - mariadb-network
+      - bench-network
   backend:
     networks:
-      - mariadb-network
+      - bench-network
   websocket:
     networks:
-      - mariadb-network
+      - bench-network
   scheduler:
     networks:
-      - mariadb-network
+      - bench-network
   queue-default:
     networks:
-      - mariadb-network
+      - bench-network
   queue-short:
     networks:
-      - mariadb-network
+      - bench-network
   queue-long:
     networks:
-      - mariadb-network
+      - bench-network
   redis:
     networks:
-      - mariadb-network
+      - bench-network
 
 networks:
   traefik-public:


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:
<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?
With old version, there was not option to run multiple stacks simultaneously
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Changed mariadb-network to bench-network in most services. As result, frontend service doesn't see multiple backend services.
