### PR TITLE
queue short added with mariadb network

### DIFF
--- a/docs/compose/compose.multi-bench.yaml
+++ b/docs/compose/compose.multi-bench.yaml
@@ -33,6 +33,7 @@ services:
   queue-short:
     networks:
       - bench-network
+      - mariadb-network
   queue-long:
     networks:
       - bench-network


### PR DESCRIPTION
Frappe docker version is not able to send mails in background
Email Queues are stuck due to Queue short unable to connect to 'mariadb-database' network

Please refer to the below discuss topic [Frappe Docker V13: Email Queue stuck](https://discuss.erpnext.com/t/frappe-docker-v13-email-queue-stuck/95047)

The project compose file is generated using the official frappe docker [single server setup](https://github.com/frappe/frappe_docker/blob/main/docs/single-server-example.md)

The [compose.multi-bench.yaml](https://github.com/frappe/frappe_docker/blob/main/docs/compose/compose.multi-bench.yaml) is missing mariadb-network for queue-short, due to which queue-short is not able to connect to the database and results in the following error
`pymysql.err.OperationalError: (2003, "Can't connect to MySQL server on 'mariadb-database' ([Errno -2] Name or service not known)")` 

Fix,
Add the mariadb-network to the networks for queue-short in compose.multi-bench.yaml so that queue-short can have access to mariadb.
