### PR TITLE
fix: set traefik Host in backticks

### DIFF
--- a/docs/compose/compose.custom-domain.yaml
+++ b/docs/compose/compose.custom-domain.yaml
@@ -16,7 +16,7 @@ services:
       - traefik.http.services.${ROUTER?ROUTER not set}.loadbalancer.server.port=2016
       - traefik.http.routers.${ROUTER}.service=${ROUTER}
       - traefik.http.routers.${ROUTER}.entrypoints=http
-      - traefik.http.routers.${ROUTER}.rule=Host(${SITES?SITES not set})
+      - traefik.http.routers.${ROUTER}.rule=Host(`${SITES?SITES not set}`)
       - traefik.http.middlewares.${ROUTER}.headers.customrequestheaders.Host=${BASE_SITE?BASE_SITE not set}
       - traefik.http.routers.${ROUTER}.middlewares=${ROUTER}
     networks:

--- a/docs/compose/compose.multi-bench-ssl.yaml
+++ b/docs/compose/compose.multi-bench-ssl.yaml
@@ -5,7 +5,7 @@ services:
       - traefik.http.routers.${ROUTER}-http.middlewares=https-redirect
       # ${ROUTER}-https the actual router using HTTPS
       # Uses the environment variable SITES
-      - traefik.http.routers.${ROUTER}-https.rule=Host(${SITES?SITES not set})
+      - traefik.http.routers.${ROUTER}-https.rule=Host(`${SITES?SITES not set}`)
       - traefik.http.routers.${ROUTER}-https.entrypoints=https
       - traefik.http.routers.${ROUTER}-https.tls=true
       # Use the service ${ROUTER} with the frontend

--- a/docs/compose/compose.multi-bench.yaml
+++ b/docs/compose/compose.multi-bench.yaml
@@ -9,7 +9,7 @@ services:
       - traefik.http.services.${ROUTER?ROUTER not set}.loadbalancer.server.port=8080
       - traefik.http.routers.${ROUTER}-http.service=${ROUTER}
       - traefik.http.routers.${ROUTER}-http.entrypoints=http
-      - traefik.http.routers.${ROUTER}-http.rule=Host(${SITES?SITES not set})
+      - traefik.http.routers.${ROUTER}-http.rule=Host(`${SITES?SITES not set}`)
   configurator:
     networks:
       - bench-network


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

The `Host` must be inside backticks: https://doc.traefik.io/traefik/routing/routers/#rule

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

This prevents `Error while parsing rule Host(sub.sub.example.com), error: *ast.BinaryExpr is not supported`
