### PR TITLE
fix: install dependencies for v13 on creation

### DIFF
--- a/devcontainer-example/devcontainer.json
+++ b/devcontainer-example/devcontainer.json
@@ -14,6 +14,7 @@
   "dockerComposeFile": "./docker-compose.yml",
   "service": "frappe",
   "workspaceFolder": "/workspace/development",
+  "onCreateCommand": "sudo apt update && sudo apt upgrade && sudo apt install -y python3-venv python3.9-dev",
   "shutdownAction": "stopCompose",
   "extensions": [
     "ms-python.python",


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Added dependencies necessary to install version 13 of Frappe & ERPNext (For Dev Container)

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The objective is to spin off the container without worrying about installing basic dependencies.
