### PR TITLE
Update default NodeJS version in development/README.md

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -68,7 +68,7 @@ bench init --skip-redis-config-generation frappe-bench
 cd frappe-bench
 ```
 
-To setup frappe framework version 14 bench set `PYENV_VERSION` environment variable to `3.10.5` (default) and use NodeJS version 14 (default),
+To setup frappe framework version 14 bench set `PYENV_VERSION` environment variable to `3.10.5` (default) and use NodeJS version 16 (default),
 
 ```shell
 # Use default environments


### PR DESCRIPTION
The default NodeJS version is 16 for frappe version 14. Updated that in the `development/README.md`.
