### PR TITLE
feat: make proxy read timeout configurable via env

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -35,6 +35,7 @@ services:
       UPSTREAM_REAL_IP_ADDRESS: ${UPSTREAM_REAL_IP_ADDRESS:-127.0.0.1}
       UPSTREAM_REAL_IP_HEADER: ${UPSTREAM_REAL_IP_HEADER:-X-Forwarded-For}
       UPSTREAM_REAL_IP_RECURSIVE: ${UPSTREAM_REAL_IP_RECURSIVE:-off}
+      PROXY_READ_TIMOUT: ${PROXY_READ_TIMOUT:-120}
     volumes:
       - sites:/usr/share/nginx/html/sites
       - assets:/usr/share/nginx/html/assets

--- a/example.env
+++ b/example.env
@@ -38,3 +38,7 @@ UPSTREAM_REAL_IP_HEADER=
 # is replaced by the last address sent in the request header field defined by the real_ip_header directive.
 # If recursive search is enabled, the original client address that matches one of the trusted addresses is replaced by the last non-trusted address sent in the request header field.
 UPSTREAM_REAL_IP_RECURSIVE=
+
+# All Values Allowed by nginx proxy_read_timeout are allowed, default value is 120s
+# Useful if you have longrunning print formats or slow loading sites
+PROXY_READ_TIMOUT=

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -42,6 +42,9 @@ RUN git clone --depth 1 ${BENCH_REPO} /tmp/bench \
 
 FROM nginxinc/nginx-unprivileged:1.23.1-alpine as frappe
 
+# Set default ENV variables for backwards compatibility
+ENV PROXY_READ_TIMOUT=120
+
 # https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/stable/alpine/20-envsubst-on-templates.sh
 COPY nginx-template.conf /etc/nginx/templates/default.conf.template
 # https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/stable/alpine/docker-entrypoint.sh

--- a/images/nginx/nginx-template.conf
+++ b/images/nginx/nginx-template.conf
@@ -72,7 +72,7 @@ server {
 		proxy_set_header X-Frappe-Site-Name ${FRAPPE_SITE_NAME_HEADER};
 		proxy_set_header Host $host;
 		proxy_set_header X-Use-X-Accel-Redirect True;
-		proxy_read_timeout 120;
+		proxy_read_timeout ${PROXY_READ_TIMOUT};
 		proxy_redirect off;
 
 		proxy_pass  http://backend-server;

--- a/pwd.yml
+++ b/pwd.yml
@@ -87,6 +87,7 @@ services:
       UPSTREAM_REAL_IP_ADDRESS: 127.0.0.1
       UPSTREAM_REAL_IP_HEADER: X-Forwarded-For
       UPSTREAM_REAL_IP_RECURSIVE: "off"
+      PROXY_READ_TIMOUT: 120
     volumes:
       - sites:/usr/share/nginx/html/sites
       - assets:/usr/share/nginx/html/assets


### PR DESCRIPTION
This solves issues with multi document Print, which might take more than 2mins and allows the behaviour to be overridden while keeping the sane defaults