### PR TITLE
fix: add git to worker image

### DIFF
--- a/images/worker/Dockerfile
+++ b/images/worker/Dockerfile
@@ -73,7 +73,7 @@ ENV NVM_DIR=/home/frappe/.nvm
 ENV PATH ${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}
 RUN apt-get update \
     # Setup Node lists
-    && apt-get install --no-install-recommends -y curl \
+    && apt-get install --no-install-recommends -y curl git \
     # NodeJS with NVM
     && mkdir -p ${NVM_DIR} \
     && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash \

--- a/images/worker/install-app.sh
+++ b/images/worker/install-app.sh
@@ -6,8 +6,6 @@ APP=$1
 
 cd /home/frappe/frappe-bench
 
-rm -rf "apps/$APP/.git"
-
 env/bin/pip install -e "apps/$APP"
 
 echo "$APP" >>sites/apps.txt


### PR DESCRIPTION
Installing erpnext sometimes causes this error, may be related to git not installed.

```
An error occurred while installing erpnext: 
Traceback (most recent call last):
  File "apps/frappe/frappe/installer.py", line 218, in fetch_details_from_tag
    org, repo = org_repo
ValueError: not enough values to unpack (expected 2, got 1)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "apps/frappe/frappe/commands/site.py", line 413, in install_app
    _install_app(app, verbose=context.verbose, force=force)
  File "apps/frappe/frappe/installer.py", line 268, in install_app
    required_app = parse_app_name(app)
  File "apps/frappe/frappe/installer.py", line 248, in parse_app_name
    _, repo, _ = fetch_details_from_tag(name)
  File "apps/frappe/frappe/installer.py", line 220, in fetch_details_from_tag
    org, repo = find_org(org_repo[0])
  File "apps/frappe/frappe/installer.py", line 194, in find_org
    raise InvalidRemoteException
frappe.exceptions.InvalidRemoteException
```