### PR TITLE
fix: redis service context error

### DIFF
--- a/overrides/compose.multi-bench.yaml
+++ b/overrides/compose.multi-bench.yaml
@@ -38,7 +38,17 @@ services:
     networks:
       - bench-network
       - mariadb-network
-  redis:
+  redis-cache:
+    networks:
+      - bench-network
+      - mariadb-network
+
+  redis-queue:
+    networks:
+      - bench-network
+      - mariadb-network
+
+  redis-socketio:
     networks:
       - bench-network
       - mariadb-network


### PR DESCRIPTION
https://discuss.frappe.io/t/service-redis-has-neither-an-image-nor-a-build-context-specified-invalid-compose-project/99936
