### PR TITLE
feat: add traefik restart policy

### DIFF
--- a/overrides/compose.traefik.yaml
+++ b/overrides/compose.traefik.yaml
@@ -3,6 +3,7 @@ version: "3.3"
 services:
   traefik:
     image: "traefik:v2.6"
+    restart: unless-stopped
     labels:
       # Enable Traefik for this service, to make it available in the public network
       - traefik.enable=true


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
While making the compose files to deploy an instance of ERPNext I noticed that the traefik service doesn't has a restart policy as it does the database image.
This PR includes the policy for the treafik service