### PR TITLE
Retrieving Assets volume 

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -55,8 +55,6 @@ services:
       UPSTREAM_REAL_IP_RECURSIVE: ${UPSTREAM_REAL_IP_RECURSIVE:-off}
       PROXY_READ_TIMOUT: ${PROXY_READ_TIMOUT:-120}
       CLIENT_MAX_BODY_SIZE: ${CLIENT_MAX_BODY_SIZE:-50m}
-    volumes:
-      - sites:/home/frappe/frappe-bench/sites
     depends_on:
       - backend
       - websocket
@@ -67,8 +65,6 @@ services:
     command:
       - node
       - /home/frappe/frappe-bench/apps/frappe/socketio.js
-    volumes:
-      - sites:/home/frappe/frappe-bench/sites
 
   queue-short:
     <<: *backend_defaults
@@ -89,3 +85,4 @@ services:
 # ERPNext requires local assets access (Frappe does not)
 volumes:
   sites:
+  assets:

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,6 +3,9 @@ x-customizable-image: &customizable_image
   # See https://github.com/frappe/frappe_docker/blob/main/docs/custom-apps.md
   # about using custom images.
   image: frappe/erpnext:${ERPNEXT_VERSION:?No ERPNext version set}
+  volumes:
+    - assets:/home/frappe/frappe-bench/sites/assets:ro
+    - sites:/home/frappe/frappe-bench/sites
 
 x-depends-on-configurator: &depends_on_configurator
   depends_on:
@@ -12,9 +15,6 @@ x-depends-on-configurator: &depends_on_configurator
 x-backend-defaults: &backend_defaults
   <<: *depends_on_configurator
   <<: *customizable_image
-  volumes:
-    - sites:/home/frappe/frappe-bench/sites
-    - assets:/home/frappe/frappe-bench/sites/assets:ro
 
 services:
   configurator:

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,8 @@ x-depends-on-configurator: &depends_on_configurator
   depends_on:
     configurator:
       condition: service_completed_successfully
+    populate-assets:
+      condition: service_completed_successfully
 
 x-backend-defaults: &backend_defaults
   <<: *depends_on_configurator
@@ -37,6 +39,16 @@ services:
       REDIS_QUEUE: ${REDIS_QUEUE}
       REDIS_SOCKETIO: ${REDIS_SOCKETIO}
       SOCKETIO_PORT: 9000
+    depends_on: {}
+
+  populate-assets:
+    <<: *customizable_image
+    entrypoint: ["sh", "-c"]
+    command:
+      - >
+        cp -fR /home/frappe/frappe-bench/sites/assets /data;
+    volumes:
+      - assets:/data/assets:rw
     depends_on: {}
 
   backend:

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,7 @@ x-backend-defaults: &backend_defaults
   <<: *customizable_image
   volumes:
     - sites:/home/frappe/frappe-bench/sites
+    - assets:/home/frappe/frappe-bench/sites/assets:ro
 
 services:
   configurator:

--- a/docs/migrate-from-multi-image-setup.md
+++ b/docs/migrate-from-multi-image-setup.md
@@ -8,8 +8,6 @@ Now you need to specify command and environment variables for following containe
 
 For `frontend` service to act as static assets frontend and reverse proxy, you need to pass `nginx-entrypoint.sh` as container `command` and `BACKEND` and `SOCKETIO` environment variables pointing `{host}:{port}` for gunicorn and websocket services. Check [environment variables](environment-variables.md)
 
-Now you only need to mount the `sites` volume at location `/home/frappe/frappe-bench/sites`.
-
 Example change:
 
 ```yaml

--- a/docs/migrate-from-multi-image-setup.md
+++ b/docs/migrate-from-multi-image-setup.md
@@ -8,7 +8,7 @@ Now you need to specify command and environment variables for following containe
 
 For `frontend` service to act as static assets frontend and reverse proxy, you need to pass `nginx-entrypoint.sh` as container `command` and `BACKEND` and `SOCKETIO` environment variables pointing `{host}:{port}` for gunicorn and websocket services. Check [environment variables](environment-variables.md)
 
-Now you only need to mount the `sites` volume at location `/home/frappe/frappe-bench/sites`. No need for `assets` volume and asset population script or steps.
+Now you only need to mount the `sites` volume at location `/home/frappe/frappe-bench/sites`.
 
 Example change:
 

--- a/docs/setup-options.md
+++ b/docs/setup-options.md
@@ -121,6 +121,9 @@ docker compose --project-name <project-name> -f ~/gitops/docker-compose.yml pull
 # Stop containers
 docker compose --project-name <project-name> -f ~/gitops/docker-compose.yml down
 
+# Remove assets volume for repopulation
+docker volume rm <name of assets volume>
+
 # Restart containers
 docker compose --project-name <project-name> -f ~/gitops/docker-compose.yml up -d
 ```

--- a/pwd.yml
+++ b/pwd.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs
+      - assets:/home/frappe/frappe-bench/sites/assets:ro
 
   configurator:
     image: frappe/erpnext:v14.15.1
@@ -36,6 +37,7 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs
+      - assets:/home/frappe/frappe-bench/sites/assets:ro
 
   create-site:
     image: frappe/erpnext:v14.15.1
@@ -45,6 +47,7 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs
+      - assets:/home/frappe/frappe-bench/sites/assets:ro
     entrypoint:
       - bash
       - -c
@@ -107,6 +110,7 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs
+      - assets:/home/frappe/frappe-bench/sites/assets:ro
     ports:
       - "8080:8080"
 
@@ -123,6 +127,7 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs
+      - assets:/home/frappe/frappe-bench/sites/assets:ro
 
   queue-long:
     image: frappe/erpnext:v14.15.1
@@ -137,6 +142,7 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs
+      - assets:/home/frappe/frappe-bench/sites/assets:ro
 
   queue-short:
     image: frappe/erpnext:v14.15.1
@@ -151,6 +157,7 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs
+      - assets:/home/frappe/frappe-bench/sites/assets:ro
 
   redis-queue:
     image: redis:6.2-alpine
@@ -187,6 +194,7 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs
+      - assets:/home/frappe/frappe-bench/sites/assets:ro
 
   websocket:
     image: frappe/erpnext:v14.15.1
@@ -206,4 +214,5 @@ volumes:
   redis-cache-data:
   redis-socketio-data:
   sites:
+  assets:
   logs:


### PR DESCRIPTION
Since the assets directory is inside the `sites` volume, it will keep the first data of initialization.
So If any new files come up with a new image it will not appears and will show an error like this:

![image](https://user-images.githubusercontent.com/83924106/217243002-d4c79196-afd1-4f3f-99cc-cbb68ae9b008.png)

So we have to retrieve the volume of the asset and do the population when updating.
