### PR TITLE
fix: default config for production

### DIFF
--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -116,8 +116,7 @@ RUN export APP_INSTALL_ARGS="" && \
     --verbose \
     /home/frappe/frappe-bench && \
   cd /home/frappe/frappe-bench && \
-  echo "$(jq 'del(.db_host, .redis_cache, .redis_queue, .redis_socketio)' sites/common_site_config.json)" \
-    > sites/common_site_config.json && \
+  echo "{}" > sites/common_site_config.json && \
   find apps -mindepth 1 -path "*/.git" | xargs rm -fr
 
 FROM base as backend

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -107,8 +107,7 @@ RUN bench init \
   /home/frappe/frappe-bench && \
   cd /home/frappe/frappe-bench && \
   bench get-app --branch=${ERPNEXT_BRANCH} --resolve-deps erpnext ${ERPNEXT_REPO} && \
-  echo "$(jq 'del(.db_host, .redis_cache, .redis_queue, .redis_socketio)' sites/common_site_config.json)" \
-    > sites/common_site_config.json && \
+  echo "{}" > sites/common_site_config.json && \
   find apps -mindepth 1 -path "*/.git" | xargs rm -fr
 
 FROM base as erpnext


### PR DESCRIPTION
reported here https://discuss.frappe.io/t/frappe-docker-2023-production-setup-password-reset-email-link-added-with-port-8000/101844
