### PR TITLE
Revert "Build arm64 images in addition to amd64 images (#1098)"

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -34,12 +34,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v1
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: all
-
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v2
         with:
@@ -80,4 +74,3 @@ jobs:
         uses: docker/bake-action@v2.3.0
         with:
           push: true
-          set: "*.platform=linux/amd64,linux/arm64"


### PR DESCRIPTION
Builds are too slow on GH runners. Need to find a better alternative.