### PR TITLE
fix: yaml import formatting in compose file

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -10,8 +10,7 @@ x-depends-on-configurator: &depends_on_configurator
       condition: service_completed_successfully
 
 x-backend-defaults: &backend_defaults
-  <<: *depends_on_configurator
-  <<: *customizable_image
+  <<: [*depends_on_configurator, *customizable_image]
   volumes:
     - sites:/home/frappe/frappe-bench/sites
 
@@ -62,8 +61,7 @@ services:
       - websocket
 
   websocket:
-    <<: *depends_on_configurator
-    <<: *customizable_image
+    <<: [*depends_on_configurator, *customizable_image]
     command:
       - node
       - /home/frappe/frappe-bench/apps/frappe/socketio.js


### PR DESCRIPTION
With the changes in the recent docker compose version the Imports need to be changed to the correct format according to yaml spec.

As Reference See:
https://github.com/docker/compose/issues/10411
https://yaml.org/type/merge.html