### PR TITLE
fix(data persistency): docker volume persistency issue

### DIFF
--- a/overrides/compose.postgres.yaml
+++ b/overrides/compose.postgres.yaml
@@ -12,7 +12,7 @@ services:
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD:?No db password set}
     volumes:
-      - db-data:/var/lib/postgresql
+      - db-data:/var/lib/postgresql/data
 
 volumes:
   db-data:


### PR DESCRIPTION
because of the missing **/data** in path, there was an issue wherein the data would be lost after docker compose down.
I looked at the official docker hub of postgres and **/var/lib/postgresql/data** this was the default in it as well.
I have attached an image below for reference.
![image](https://github.com/frappe/frappe_docker/assets/122703615/f448b020-3aee-4466-95e2-fc356d2c691f)


