### PR TITLE
Fix typo in PROXY_READ_TIMEOUT in .env and pwd.yaml

### DIFF
--- a/example.env
+++ b/example.env
@@ -38,7 +38,7 @@ UPSTREAM_REAL_IP_RECURSIVE=
 
 # All Values Allowed by nginx proxy_read_timeout are allowed, default value is 120s
 # Useful if you have longrunning print formats or slow loading sites
-PROXY_READ_TIMOUT=
+PROXY_READ_TIMEOUT=
 
 # All Values allowed by nginx client_max_body_size are allowed, default value is 50m
 # Necessary if the upload limit in the frappe application is increased

--- a/pwd.yml
+++ b/pwd.yml
@@ -103,7 +103,7 @@ services:
       UPSTREAM_REAL_IP_ADDRESS: 127.0.0.1
       UPSTREAM_REAL_IP_HEADER: X-Forwarded-For
       UPSTREAM_REAL_IP_RECURSIVE: "off"
-      PROXY_READ_TIMOUT: 120
+      PROXY_READ_TIMEOUT: 120
       CLIENT_MAX_BODY_SIZE: 50m
     volumes:
       - sites:/home/frappe/frappe-bench/sites


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

The Nginx variable `PROXY_READ_TIMEOUT` is misspelled as `PROXY_READ_TIMOUT`, causing it to not update in the configuration file. This misspelling leads to an issue where the value is not being properly updated in the config file.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

This PR will solve the issue and will update variable in configuration file correctly.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

### The screenshot below illustrates that the value for `TIMEOUT` has not been updated in the configuration file, while the value for `client_max_body_size` has been successfully updated.
![image](https://github.com/frappe/frappe_docker/assets/25708027/636cd065-525d-4579-87eb-12f0c8caa897)
### Value provided via .env file
![image](https://github.com/frappe/frappe_docker/assets/25708027/baa059f4-0a9c-416b-89fd-91c27372568f)



