### PR TITLE
Tag bench images with the latest bench release version

### DIFF
--- a/.github/workflows/build_bench.yml
+++ b/.github/workflows/build_bench.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Set Environment Variables
         run: cat example.env | grep -o '^[^#]*' >> "$GITHUB_ENV"
 
+      - name: Get Bench Latest Version
+        run: echo "LATEST_BENCH_RELEASE=$(curl -s 'https://api.github.com/repos/frappe/bench/releases/latest' | jq -r '.tag_name')" >> "$GITHUB_ENV"
+
       - name: Build and test
         uses: docker/bake-action@v3.1.0
         with:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -32,6 +32,10 @@ variable "BENCH_REPO" {
     default = "https://github.com/frappe/bench"
 }
 
+variable "LATEST_BENCH_RELEASE" {
+    default = "latest"
+}
+
 # Bench image
 
 target "bench" {
@@ -40,7 +44,7 @@ target "bench" {
     }
     context = "images/bench"
     target = "bench"
-    tags = ["frappe/bench:latest"]
+    tags = ["frappe/bench:${LATEST_BENCH_RELEASE}"]
 }
 
 target "bench-test" {


### PR DESCRIPTION
Remove latest tag and make it default

Fixes #1135

Earlier when the bench docker image was build from the develop branch of the[ frappe/bench](https://github.com/frappe/bench) repository, there were issues in the [frappe/bench:latest](https://hub.docker.com/r/frappe/bench) images that caused other applications or sites that used the image to cause error.

And there is only a single bench docker image in the Docker Hub with the tag _latest_. The bench docker image is always replaced by the new bench image, making it difficult to stick to a particular tag of the bench image.

Solution:

Currently whenever a docker image is being build it will check for the latest release of the bench in the [frappe/bench](https://github.com/frappe/bench) repository, and use that as the tag for the new docker image. Making it possible to tag a particular version of bench in dockerfiles.