### PR TITLE
Broken link to environment variables definition fixed

### DIFF
--- a/docs/setup-options.md
+++ b/docs/setup-options.md
@@ -17,7 +17,7 @@ Copy the example docker environment file to `.env`:
 cp example.env .env
 ```
 
-Note: To know more about environment variable [read here](./images-and-compose-files.md#configuration). Set the necessary variables in the `.env` file.
+Note: To know more about environment variable [read here](./environment-variables.md). Set the necessary variables in the `.env` file.
 
 ## Generate docker-compose.yml for variety of setups
 


### PR DESCRIPTION
The setup-options page links to the environment variables, but the link is broken as it has been refactored to a new file in PR #400. This change fixes the broken link to connect to the [environment variables](https://github.com/frappe/frappe_docker/blob/main/docs/environment-variables.md) md file