### PR TITLE
frontend depends_on websocket to avoid error on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ development/*
 *.pyc
 __pycache__
 venv
+
+# NodeJS
+node_modules

--- a/devcontainer-example/devcontainer.json
+++ b/devcontainer-example/devcontainer.json
@@ -5,11 +5,11 @@
   "settings": {
     "terminal.integrated.profiles.linux": {
       "frappe bash": {
-        "path": "/bin/bash"
-      }
+        "path": "/bin/bash",
+      },
     },
     "terminal.integrated.defaultProfile.linux": "frappe bash",
-    "debug.node.autoAttach": "disabled"
+    "debug.node.autoAttach": "disabled",
   },
   "dockerComposeFile": "./docker-compose.yml",
   "service": "frappe",
@@ -20,6 +20,6 @@
     "ms-vscode.live-server",
     "grapecity.gc-excelviewer",
     "mtxr.sqltools",
-    "visualstudioexptteam.vscodeintellicode"
-  ]
+    "visualstudioexptteam.vscodeintellicode",
+  ],
 }

--- a/pwd.yml
+++ b/pwd.yml
@@ -90,6 +90,8 @@ services:
 
   frontend:
     image: frappe/erpnext:v15.10.3
+    depends_on:
+      - websocket
     deploy:
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

I tend to run open source project locally, preferably by running the docker compose. I ran it using `docker-compose -f ./pwd.yml up -d`.

> Explain the **details** for making this change. What existing problem does the pull request solve?

After running docker compose, the `frontend` container is dead. Doing `docker logs frappe_docker_frontend_1` reveals the log below:

```
2024/01/23 10:46:13 [emerg] 3#3: host not found in upstream "websocket:9000" in /etc/nginx/conf.d/frappe.conf:6
```

This mean the websocket service has not yet started when running frontend. To fix this, I use `depends_on` attribute for the frontend service. https://docs.docker.com/compose/compose-file/compose-file-v3/#depends_on.