### PR TITLE
fix: Fix gpg and less

### DIFF
--- a/docs/single-server-example.md
+++ b/docs/single-server-example.md
@@ -82,6 +82,8 @@ EMAIL=admin@example.com
 HASHED_PASSWORD=$apr1$K.4gp7RT$tj9R2jHh0D4Gb5o5fIAzm/
 ```
 
+If Container does not deploy put the HASHED_PASSWORD in ''.
+
 Deploy the traefik container with letsencrypt SSL
 
 ```shell
@@ -91,7 +93,7 @@ docker compose --project-name traefik \
   -f overrides/compose.traefik-ssl.yaml up -d
 ```
 
-This will make the traefik dashboard available on `traefik.example.com` and all certificates will reside in `/data/traefik/certificates` on host filesystem.
+This will make the traefik dashboard available on `traefik.example.com` and all certificates will reside in the Docker volume `cert-data`.
 
 For LAN setup deploy the traefik container without overriding `overrides/compose.traefik-ssl.yaml`.
 

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -26,8 +26,10 @@ RUN useradd -ms /bin/bash frappe \
     libpangocairo-1.0-0 \
     # For backups
     restic \
+    gpg \
     # MariaDB
     mariadb-client \
+    less \    
     # Postgres
     libpq-dev \
     postgresql-client \

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -29,7 +29,7 @@ RUN useradd -ms /bin/bash frappe \
     gpg \
     # MariaDB
     mariadb-client \
-    less \    
+    less \
     # Postgres
     libpq-dev \
     postgresql-client \

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -26,7 +26,7 @@ RUN useradd -ms /bin/bash frappe \
     gpg \
     # MariaDB
     mariadb-client \
-    less \ 
+    less \
     # Postgres
     libpq-dev \
     postgresql-client \

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -23,8 +23,10 @@ RUN useradd -ms /bin/bash frappe \
     libpangocairo-1.0-0 \
     # For backups
     restic \
+    gpg \
     # MariaDB
     mariadb-client \
+    less \ 
     # Postgres
     libpq-dev \
     postgresql-client \


### PR DESCRIPTION
Add "gpg" and "less" to the Containerfiles.

fix: #1301 
fix: Add gpg so backup "bench --site yoursite.com backup --with-files --compress" does not fail if encryption is enabled

update: documenation for single server to current status