### PR TITLE
fix: grammar and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Everything about [Frappe](https://github.com/frappe/frappe) and [ERPNext](https:
 
 # Getting Started
 
-To get started, you need Docker, docker-compose and git setup on your machine. For Docker basics and best practices. Refer Docker [documentation](http://docs.docker.com).
+To get started you need [Docker](https://docs.docker.com/get-docker/), [docker-compose](https://docs.docker.com/compose/), and [git](https://docs.github.com/en/get-started/getting-started-with-git/set-up-git) setup on your machine. For Docker basics and best practices refer to Docker's [documentation](http://docs.docker.com).
 After that, clone this repo:
 
 ```sh


### PR DESCRIPTION
Made grammar corrections, and added links to the prerequisite installations to save someone time if they are not installed.
