### PR TITLE
fix: add file cmd install because "bench restore" need it

### DIFF
--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -69,6 +69,7 @@ RUN apt-get update \
     xz-utils \
     tk-dev \
     liblzma-dev \
+    file \
     && rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \


### PR DESCRIPTION

> Please provide enough information so that others can review your pull request:

In frappe develop branch (but it will not hurt previous version)

`bench --site XXX restore ....`

will use "file" linux/unix command

https://github.com/frappe/frappe/blob/b044ffedf12989242d29e92fb069518cb306bdfc/frappe/commands/site.py#L176 

> Explain the **details** for making this change. What existing problem does the pull request solve?

It seems that on docker debian:bookworm-slim this command is not installed by default, but it have to be in the bench container
`bench --site XXX restore ....`

This may be required only for development purpose, but still in next frappe release it could be required for production image, depend on how `bench --site XXX restore ....` will be used
