### PR TITLE
feat: add defaultInterpreterPath as a vscode setting as a starting point according to docs

### DIFF
--- a/development/vscode-example/settings.json
+++ b/development/vscode-example/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}/frappe-bench/env/bin/python"
+}


### PR DESCRIPTION
See: https://github.com/microsoft/vscode-python/wiki/Setting-descriptions#pythondefaultinterpreterpath

This only adds a default settings.json file to local setup in container to make initial setup a bit more streamlined.
