### PR TITLE
fix: add missing file package for bench restore

### DIFF
--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -19,6 +19,7 @@ RUN useradd -ms /bin/bash frappe \
     vim \
     nginx \
     gettext-base \
+    file \
     # weasyprint dependencies
     libpango-1.0-0 \
     libharfbuzz0b \

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -16,6 +16,7 @@ RUN useradd -ms /bin/bash frappe \
     vim \
     nginx \
     gettext-base \
+    file \
     # weasyprint dependencies
     libpango-1.0-0 \
     libharfbuzz0b \


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

file package is missing in debian bookworm and it's used in `bench restore` command as mentioned in #1343 

> Explain the **details** for making this change. What existing problem does the pull request solve?

#1343 fixed only the Dockerfile under **bench** this pr fixes the other two under **custom** and **production**