### PR TITLE
Update single-server-example.md

### DIFF
--- a/docs/single-server-example.md
+++ b/docs/single-server-example.md
@@ -65,7 +65,7 @@ Create a file called `traefik.env` in `~/gitops`
 ```shell
 echo 'TRAEFIK_DOMAIN=traefik.example.com' > ~/gitops/traefik.env
 echo 'EMAIL=admin@example.com' >> ~/gitops/traefik.env
-echo 'HASHED_PASSWORD='$(openssl passwd -apr1 changeit | sed 's/\$/\\\$/g') >> ~/gitops/traefik.env
+echo 'HASHED_PASSWORD='$(openssl passwd -apr1 changeit | sed -e s/\\$/\\$\\$/g) >> ~/gitops/traefik.env
 ```
 
 Note:


### PR DESCRIPTION
Fix nonworking step - hashed password fails - per https://discuss.frappe.io/t/frappe-docker-unable-to-log-in-into-traefik/123077


Following the single-server-example fails at the traefik step due to the incorrect password hash, making login impossible.