### PR TITLE
#1402 Environment variables for custom image

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
+level of experience, education, socioeconomic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,8 @@ x-customizable-image: &customizable_image
   # By default the image used only contains the `frappe` and `erpnext` apps.
   # See https://github.com/frappe/frappe_docker/blob/main/docs/custom-apps.md
   # about using custom images.
-  image: frappe/erpnext:${ERPNEXT_VERSION:?No ERPNext version set}
+  image: ${CUSTOM_IMAGE:-frappe/erpnext}:${ERPNEXT_VERSION:-${CUSTOM_TAG:?No ERPNext version or tag set}}
+  pull_policy: ${PULL_POLICY:-always}
 
 x-depends-on-configurator: &depends_on_configurator
   depends_on:

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ x-customizable-image: &customizable_image
   # By default the image used only contains the `frappe` and `erpnext` apps.
   # See https://github.com/frappe/frappe_docker/blob/main/docs/custom-apps.md
   # about using custom images.
-  image: ${CUSTOM_IMAGE:-frappe/erpnext}:${ERPNEXT_VERSION:-${CUSTOM_TAG:?No ERPNext version or tag set}}
+  image: ${CUSTOM_IMAGE:-frappe/erpnext}:${CUSTOM_TAG:-${ERPNEXT_VERSION:?No ERPNext version or tag set}}
   pull_policy: ${PULL_POLICY:-always}
 
 x-depends-on-configurator: &depends_on_configurator

--- a/compose.yaml
+++ b/compose.yaml
@@ -33,10 +33,10 @@ services:
         bench set-config -g redis_socketio "redis://$$REDIS_QUEUE";
         bench set-config -gp socketio_port $$SOCKETIO_PORT;
     environment:
-      DB_HOST: ${DB_HOST}
-      DB_PORT: ${DB_PORT}
-      REDIS_CACHE: ${REDIS_CACHE}
-      REDIS_QUEUE: ${REDIS_QUEUE}
+      DB_HOST: ${DB_HOST:-}
+      DB_PORT: ${DB_PORT:-}
+      REDIS_CACHE: ${REDIS_CACHE:-}
+      REDIS_QUEUE: ${REDIS_QUEUE:-}
       SOCKETIO_PORT: 9000
     depends_on: {}
 

--- a/docs/custom-apps.md
+++ b/docs/custom-apps.md
@@ -103,15 +103,38 @@ podman run --rm -it \
 More about [kaniko](https://github.com/GoogleContainerTools/kaniko)
 
 ### Use Images
+In the [compose.yaml](../compose.yaml), you can set the image name and tag through environment variables, making it easier to customize.
 
-On the [compose.yaml](../compose.yaml) replace the image reference to the `tag` you used when you built it. Then, if you used a tag like `custom_erpnext:staging` the `x-customizable-image` section will look like this:
-
-```
+```yaml
 x-customizable-image: &customizable_image
-  image: custom_erpnext:staging
-  pull_policy: never
+  image: ${CUSTOM_IMAGE:-frappe/erpnext}:${ERPNEXT_VERSION:-${CUSTOM_TAG:?No ERPNext version or tag set}}
+  pull_policy: ${PULL_POLICY:-always}
 ```
 
-The `pull_policy` above is optional and prevents `docker` to try to download the image when that one has been built locally.
+The environment variables can be set in the shell or in the .env file as [setup-options.md](setup-options.md) describes.
+
+- `CUSTOM_IMAGE`: The name of your custom image. Defaults to `frappe/erpnext` if not set.
+- `CUSTOM_TAG`: The tag for your custom image. Must be set if `CUSTOM_IMAGE` is used. 
+- `PULL_POLICY`: The Docker pull policy. Defaults to `always`. Recommended set to `never` for custom images, so prevent `docker` from trying to download the image when it has been built locally.
+- `HTTP_PUBLISH_PORT`: The port to publish trough no SSL channel. Default depending on deployment, it may be `80` if SSL activated or `8080` if not.
+- `HTTPS_PUBLISH_PORT`: The secure port to publish using SSL. Default is `443`.
+
+> **Note**: As `CUSTOM_TAG` environment variable is intended to be used for a custom image, it is required to comment out the `ERPNEXT_VERSION` environment variable in the .env file.
 
 Make sure image name is correct to be pushed to registry. After the images are pushed, you can pull them to servers to be deployed. If the registry is private, additional auth is needed.
+
+#### Example
+
+If you built an image with the tag `ghcr.io/user/repo/custom:1.0.0`, you would set the environment variables as follows:
+
+```bash
+# Comment out ERPNEXT_VERSION in .env
+export CUSTOM_IMAGE='ghcr.io/user/repo/custom'
+export CUSTOM_TAG='1.0.0'
+export PULL_POLICY='never'
+docker compose -f compose.yaml \
+  -f overrides/compose.mariadb.yaml \
+  -f overrides/compose.redis.yaml \
+  -f overrides/compose.htts.yaml \
+  config > ~/gitops/docker-compose.yaml
+```

--- a/docs/custom-apps.md
+++ b/docs/custom-apps.md
@@ -107,19 +107,17 @@ In the [compose.yaml](../compose.yaml), you can set the image name and tag throu
 
 ```yaml
 x-customizable-image: &customizable_image
-  image: ${CUSTOM_IMAGE:-frappe/erpnext}:${ERPNEXT_VERSION:-${CUSTOM_TAG:?No ERPNext version or tag set}}
+  image: ${CUSTOM_IMAGE:-frappe/erpnext}:${CUSTOM_TAG:-${ERPNEXT_VERSION:?No ERPNext version or tag set}}
   pull_policy: ${PULL_POLICY:-always}
 ```
 
 The environment variables can be set in the shell or in the .env file as [setup-options.md](setup-options.md) describes.
 
 - `CUSTOM_IMAGE`: The name of your custom image. Defaults to `frappe/erpnext` if not set.
-- `CUSTOM_TAG`: The tag for your custom image. Must be set if `CUSTOM_IMAGE` is used. 
-- `PULL_POLICY`: The Docker pull policy. Defaults to `always`. Recommended set to `never` for custom images, so prevent `docker` from trying to download the image when it has been built locally.
+- `CUSTOM_TAG`: The tag for your custom image. Must be set if `CUSTOM_IMAGE` is used. Defaults to the value of `ERPNEXT_VERSION` if not set.
+- `PULL_POLICY`: The Docker pull policy. Defaults to `always`. Recommended set to `never` for local images, so prevent `docker` from trying to download the image when it has been built locally.
 - `HTTP_PUBLISH_PORT`: The port to publish trough no SSL channel. Default depending on deployment, it may be `80` if SSL activated or `8080` if not.
 - `HTTPS_PUBLISH_PORT`: The secure port to publish using SSL. Default is `443`.
-
-> **Note**: As `CUSTOM_TAG` environment variable is intended to be used for a custom image, it is required to comment out the `ERPNEXT_VERSION` environment variable in the .env file.
 
 Make sure image name is correct to be pushed to registry. After the images are pushed, you can pull them to servers to be deployed. If the registry is private, additional auth is needed.
 
@@ -128,10 +126,8 @@ Make sure image name is correct to be pushed to registry. After the images are p
 If you built an image with the tag `ghcr.io/user/repo/custom:1.0.0`, you would set the environment variables as follows:
 
 ```bash
-# Comment out ERPNEXT_VERSION in .env
 export CUSTOM_IMAGE='ghcr.io/user/repo/custom'
 export CUSTOM_TAG='1.0.0'
-export PULL_POLICY='never'
 docker compose -f compose.yaml \
   -f overrides/compose.mariadb.yaml \
   -f overrides/compose.redis.yaml \

--- a/docs/custom-apps.md
+++ b/docs/custom-apps.md
@@ -103,6 +103,7 @@ podman run --rm -it \
 More about [kaniko](https://github.com/GoogleContainerTools/kaniko)
 
 ### Use Images
+
 In the [compose.yaml](../compose.yaml), you can set the image name and tag through environment variables, making it easier to customize.
 
 ```yaml
@@ -116,7 +117,7 @@ The environment variables can be set in the shell or in the .env file as [setup-
 - `CUSTOM_IMAGE`: The name of your custom image. Defaults to `frappe/erpnext` if not set.
 - `CUSTOM_TAG`: The tag for your custom image. Must be set if `CUSTOM_IMAGE` is used. Defaults to the value of `ERPNEXT_VERSION` if not set.
 - `PULL_POLICY`: The Docker pull policy. Defaults to `always`. Recommended set to `never` for local images, so prevent `docker` from trying to download the image when it has been built locally.
-- `HTTP_PUBLISH_PORT`: The port to publish trough no SSL channel. Default depending on deployment, it may be `80` if SSL activated or `8080` if not.
+- `HTTP_PUBLISH_PORT`: The port to publish through no SSL channel. Default depending on deployment, it may be `80` if SSL activated or `8080` if not.
 - `HTTPS_PUBLISH_PORT`: The secure port to publish using SSL. Default is `443`.
 
 Make sure image name is correct to be pushed to registry. After the images are pushed, you can pull them to servers to be deployed. If the registry is private, additional auth is needed.
@@ -131,6 +132,6 @@ export CUSTOM_TAG='1.0.0'
 docker compose -f compose.yaml \
   -f overrides/compose.mariadb.yaml \
   -f overrides/compose.redis.yaml \
-  -f overrides/compose.htts.yaml \
+  -f overrides/compose.https.yaml \
   config > ~/gitops/docker-compose.yaml
 ```

--- a/overrides/compose.https.yaml
+++ b/overrides/compose.https.yaml
@@ -21,8 +21,8 @@ services:
       - --certificatesResolvers.main-resolver.acme.email=${LETSENCRYPT_EMAIL:?No Let's Encrypt email set}
       - --certificatesResolvers.main-resolver.acme.storage=/letsencrypt/acme.json
     ports:
-      - 80:80
-      - 443:443
+      - ${HTTP_PUBLISH_PORT:-80}:80
+      - ${HTTPS_PUBLISH_PORT:-443}:443
     volumes:
       - cert-data:/letsencrypt
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/overrides/compose.noproxy.yaml
+++ b/overrides/compose.noproxy.yaml
@@ -1,4 +1,4 @@
 services:
   frontend:
     ports:
-      - 8080:8080
+      - ${HTTP_PUBLISH_PORT:-8080}:8080

--- a/overrides/compose.proxy.yaml
+++ b/overrides/compose.proxy.yaml
@@ -13,7 +13,7 @@ services:
       - --providers.docker.exposedbydefault=false
       - --entrypoints.web.address=:80
     ports:
-      - 80:80
+      - ${HTTP_PUBLISH_PORT:-80}:80
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     userns_mode: host

--- a/overrides/compose.traefik-ssl.yaml
+++ b/overrides/compose.traefik-ssl.yaml
@@ -40,7 +40,7 @@ services:
       # Enable the Dashboard and API
       - --api
     ports:
-      - 443:443
+      - ${HTTPS_PUBLISH_PORT:-443}:443
     volumes:
       - cert-data:/certificates
 

--- a/overrides/compose.traefik.yaml
+++ b/overrides/compose.traefik.yaml
@@ -35,7 +35,7 @@ services:
       # Enable the Dashboard and API
       - --api
     ports:
-      - 80:80
+      - ${HTTP_PUBLISH_PORT:-80}:80
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:


### PR DESCRIPTION
### Details

This pull request addresses the need highlighted in the issue for enhancing the customization process within Frappe Docker deployments. The current method of manually modifying the `compose.yaml` file for custom applications, as described in the issue, can potentially lead to challenges in version control and file integrity.

To alleviate this, I propose the introduction of environment variables, including `CUSTOM_IMAGE`, `CUSTOM_TAG`, `PULL_POLICY`, `HTTP_PUBLISH_PORT` and `HTTPS_PUBLISH_PORT`, which users can leverage to customize their deployments seamlessly. This approach not only simplifies the customization process but also enhances the maintainability and consistency of Frappe Docker configurations.

By incorporating this feature, users can define their custom image names and tags directly through environment variables, facilitating smoother deployments without compromising the integrity of configuration files. Further details and discussions regarding the necessity and implementation of this enhancement are available in the associated issue.