### PR TITLE
Update docker-compose.yml

### DIFF
--- a/devcontainer-example/docker-compose.yml
+++ b/devcontainer-example/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.7"
 services:
   mariadb:
     image: docker.io/mariadb:10.6
+    platform: linux/amd64
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
@@ -37,12 +38,15 @@ services:
 
   redis-cache:
     image: docker.io/redis:alpine
+    platform: linux/amd64
 
   redis-queue:
     image: docker.io/redis:alpine
+    platform: linux/amd64
 
   frappe:
     image: docker.io/frappe/bench:latest
+    platform: linux/amd64
     command: sleep infinity
     environment:
       - SHELL=/bin/bash


### PR DESCRIPTION
A challenge I encountered while setting up the Development instance. The command 'bench init --skip-redis-config-generation frappe-bench' kept generating errors, which I discovered were due to an architecture mismatch between Docker and macOS. By updating the platform to linux/amd64 in my code, I was able to resolve this issue.
