### PR TITLE
Fix: WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match

### DIFF
--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as bench
+FROM debian:bookworm-slim AS bench
 
 LABEL author=frappé
 
@@ -145,7 +145,7 @@ RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | 
 
 EXPOSE 8000-8005 9000-9005 6787
 
-FROM bench as bench-test
+FROM bench AS bench-test
 
 # Print version and verify bashrc is properly sourced so that everything works
 # in the interactive shell and Dockerfile

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -130,7 +130,7 @@ RUN export APP_INSTALL_ARGS="" && \
   echo "{}" > sites/common_site_config.json && \
   find apps -mindepth 1 -path "*/.git" | xargs rm -fr
 
-FROM base as backend
+FROM base AS backend
 
 USER frappe
 

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -115,7 +115,7 @@ RUN bench init \
   echo "{}" > sites/common_site_config.json && \
   find apps -mindepth 1 -path "*/.git" | xargs rm -fr
 
-FROM base as erpnext
+FROM base AS erpnext
 
 USER frappe
 


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

This changes the casing of the `FROM` instruction to be consistent.

> Explain the **details** for making this change. What existing problem does the pull request solve?

It fixes the following warning which seems to have appeared with the release of Docker 27:

>  => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 133)