### PR TITLE
Fix: LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format

### DIFF
--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -98,8 +98,8 @@ WORKDIR /home/frappe
 # Install Python via pyenv
 ENV PYTHON_VERSION_V14=3.10.13
 ENV PYTHON_VERSION=3.11.6
-ENV PYENV_ROOT /home/frappe/.pyenv
-ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+ENV PYENV_ROOT=/home/frappe/.pyenv
+ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 
 # From https://github.com/pyenv/pyenv#basic-github-checkout
 RUN git clone --depth 1 https://github.com/pyenv/pyenv.git .pyenv \
@@ -114,7 +114,7 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git .pyenv \
 
 # Clone and install bench in the local user home directory
 # For development, bench source is located in ~/.bench
-ENV PATH /home/frappe/.local/bin:$PATH
+ENV PATH=/home/frappe/.local/bin:$PATH
 # Skip editable-bench warning
 # https://github.com/frappe/bench/commit/20560c97c4246b2480d7358c722bc9ad13606138
 RUN git clone ${GIT_REPO} --depth 1 -b ${GIT_BRANCH} .bench \
@@ -125,8 +125,8 @@ RUN git clone ${GIT_REPO} --depth 1 -b ${GIT_BRANCH} .bench \
 # Install Node via nvm
 ENV NODE_VERSION_14=16.20.2
 ENV NODE_VERSION=18.18.2
-ENV NVM_DIR /home/frappe/.nvm
-ENV PATH ${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}
+ENV NVM_DIR=/home/frappe/.nvm
+ENV PATH=${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}
 
 RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash \
     && . ${NVM_DIR}/nvm.sh \

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -9,7 +9,7 @@ ARG WKHTMLTOPDF_VERSION=0.12.6.1-3
 ARG WKHTMLTOPDF_DISTRO=bookworm
 ARG NODE_VERSION=18.18.2
 ENV NVM_DIR=/home/frappe/.nvm
-ENV PATH ${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}
+ENV PATH=${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}
 
 RUN useradd -ms /bin/bash frappe \
     && apt-get update \

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -6,7 +6,7 @@ ARG WKHTMLTOPDF_VERSION=0.12.6.1-3
 ARG WKHTMLTOPDF_DISTRO=bookworm
 ARG NODE_VERSION=18.18.2
 ENV NVM_DIR=/home/frappe/.nvm
-ENV PATH ${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}
+ENV PATH=${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}
 
 RUN useradd -ms /bin/bash frappe \
     && apt-get update \


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Fix: LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format

> Explain the **details** for making this change. What existing problem does the pull request solve?

This seems to be a [warning brought in by recent Docker updates.](https://docs.docker.com/reference/build-checks/legacy-key-value-format/)