### PR TITLE
Update example.env

### DIFF
--- a/example.env
+++ b/example.env
@@ -23,6 +23,9 @@ LETSENCRYPT_EMAIL=mail@example.com
 # and do want to access it by `127.0.0.1` host. Than you would set this variable to `mysite`.
 FRAPPE_SITE_NAME_HEADER=
 
+# Default value is `8080`.
+HTTP_PUBLISH_PORT=
+
 # Default value is `127.0.0.1`. Set IP address as our trusted upstream address.
 UPSTREAM_REAL_IP_ADDRESS=
 


### PR DESCRIPTION
Added the HTTP_PUBLISH_PORT variable for updating the published port. The default value is 8080. If we want to update the published port, we can specify it here.