### PR TITLE
Increase mariadb health-check timeout - fixes #1484

### DIFF
--- a/docs/setup_for_linux_mac.md
+++ b/docs/setup_for_linux_mac.md
@@ -91,7 +91,7 @@ services:
     healthcheck:
       test: mysqladmin ping -h localhost --password=admin
       interval: 1s
-      retries: 15
+      retries: 20
     deploy:
       restart_policy:
         condition: on-failure

--- a/overrides/compose.mariadb-shared.yaml
+++ b/overrides/compose.mariadb-shared.yaml
@@ -8,7 +8,7 @@ services:
     healthcheck:
       test: mysqladmin ping -h localhost --password=${DB_PASSWORD:-changeit}
       interval: 1s
-      retries: 15
+      retries: 20
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci

--- a/overrides/compose.mariadb.yaml
+++ b/overrides/compose.mariadb.yaml
@@ -12,7 +12,7 @@ services:
     healthcheck:
       test: mysqladmin ping -h localhost --password=${DB_PASSWORD}
       interval: 1s
-      retries: 15
+      retries: 20
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci

--- a/pwd.yml
+++ b/pwd.yml
@@ -74,7 +74,7 @@ services:
     healthcheck:
       test: mysqladmin ping -h localhost --password=admin
       interval: 1s
-      retries: 15
+      retries: 20
     deploy:
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
Increase health-check margin in case of any minor delays on MariaDB boot. The current time limit is quite short.

fixes #1484
