### PR TITLE
chore: add link to FAQ in production container

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ If you ran in a Dev Docker environment, to view container logs: `docker compose 
 
 # Documentation
 
+### [Frequently Asked Questions](https://github.com/frappe/frappe_docker/wiki/Frequently-Asked-Questions)
+
 ### [Production](#production)
 
 - [List of containers](docs/list-of-containers.md)

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -119,6 +119,8 @@ FROM base AS erpnext
 
 USER frappe
 
+ENV PS1='Commands restricted in prodution container, Read FAQ before you proceed: https://frappe.fyi/ctr-faq\n\u:\w\$'
+
 COPY --from=builder --chown=frappe:frappe /home/frappe/frappe-bench /home/frappe/frappe-bench
 
 WORKDIR /home/frappe/frappe-bench

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -119,7 +119,7 @@ FROM base AS erpnext
 
 USER frappe
 
-ENV PS1='Commands restricted in prodution container, Read FAQ before you proceed: https://frappe.fyi/ctr-faq\n\u:\w\$'
+RUN echo "echo \"Commands restricted in prodution container, Read FAQ before you proceed: https://frappe.fyi/ctr-faq\"" >> ~/.bashrc
 
 COPY --from=builder --chown=frappe:frappe /home/frappe/frappe-bench /home/frappe/frappe-bench
 


### PR DESCRIPTION
Prompt will show following message.

```shell
Commands restricted in prodution container, Read FAQ before you proceed: https://frappe.fyi/ctr-faq
frappe:~/frappe-bench$
```