### PR TITLE
dollar escape for ERPNEXT_VERSION

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ x-customizable-image: &customizable_image
   # By default the image used only contains the `frappe` and `erpnext` apps.
   # See https://github.com/frappe/frappe_docker/blob/main/docs/custom-apps.md
   # about using custom images.
-  image: ${CUSTOM_IMAGE:-frappe/erpnext}:${CUSTOM_TAG:-${ERPNEXT_VERSION:?No ERPNext version or tag set}}
+  image: ${CUSTOM_IMAGE:-frappe/erpnext}:$${CUSTOM_TAG:-${ERPNEXT_VERSION:?No ERPNext version or tag set}}
   pull_policy: ${PULL_POLICY:-always}
 
 x-depends-on-configurator: &depends_on_configurator


### PR DESCRIPTION

I was not able to generate the `erpnext-one.yaml` and from `erpnex-one.env` in `~/gitops` anymore.
A detailed description of the failure can be found here: https://github.com/frappe/frappe_docker/issues/1487#issue-2568736420 


By adding the "$" escape in example.yaml the process ran flawlessly again.
