### PR TITLE
fix: invalid nested interpolation (#1487)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ x-customizable-image: &customizable_image
   # By default the image used only contains the `frappe` and `erpnext` apps.
   # See https://github.com/frappe/frappe_docker/blob/main/docs/custom-apps.md
   # about using custom images.
-  image: ${CUSTOM_IMAGE:-frappe/erpnext}:${CUSTOM_TAG:-${ERPNEXT_VERSION:?No ERPNext version or tag set}}
+  image: ${CUSTOM_IMAGE:-frappe/erpnext}:${CUSTOM_TAG:-$ERPNEXT_VERSION}
   pull_policy: ${PULL_POLICY:-always}
 
 x-depends-on-configurator: &depends_on_configurator


### PR DESCRIPTION
Nested interpolation is not supported by docker (https://github.com/docker/cli/issues/4265). Changed the file so that it uses `CUSTOM_TAG` or `ERPNEXT_VERSION` if that's not available.

Fixes an issue where the compose file incorrectly throws an error below: (already reported in #1487)

```
invalid interpolation format for services.scheduler.image: "${ERPNEXT_VERSION:?No ERPNext version or tag set". You may need to escape any $ with another $.
```