### PR TITLE
ci: push frappe or erpnext branch as tag

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -37,9 +37,6 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
-    strategy:
-      matrix:
-        arch: [amd64, arm64]
 
     steps:
       - name: Checkout
@@ -49,7 +46,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
-          platforms: linux/${{ matrix.arch }}
 
       - name: Get latest versions
         run: python3 ./.github/scripts/get_latest_tags.py --repo ${{ inputs.repo }} --version ${{ inputs.version }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -37,6 +37,9 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
 
     steps:
       - name: Checkout
@@ -46,6 +49,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
+          platforms: linux/${{ matrix.arch }}
 
       - name: Get latest versions
         run: python3 ./.github/scripts/get_latest_tags.py --repo ${{ inputs.repo }} --version ${{ inputs.version }}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -65,6 +65,8 @@ group "default" {
 function "tag" {
     params = [repo, version]
     result = [
+      # Push frappe or erpnext branch as tag
+      "${REGISTRY_USER}/${repo}:${version}",
       # If `version` param is develop (development build) then use tag `latest`
       "${version}" == "develop" ? "${REGISTRY_USER}/${repo}:latest" : "${REGISTRY_USER}/${repo}:${version}",
       # Make short tag for major version if possible. For example, from v13.16.0 make v13.
@@ -107,5 +109,5 @@ target "build" {
     context = "."
     dockerfile = "images/production/Containerfile"
     target = "build"
-    tags = tag("build", "${FRAPPE_VERSION}")
+    tags = tag("build", "${ERPNEXT_VERSION}")
 }


### PR DESCRIPTION
Following images now available

- `frappe/base:develop`
- `frappe/build:develop`
- `frappe/erpnext:develop`