### PR TITLE
fix: --no-mariadb-socket is DEPRECATED

### DIFF
--- a/development/installer.py
+++ b/development/installer.py
@@ -209,7 +209,7 @@ def create_site_in_bench(args):
             "new-site",
             f"--db-host=mariadb",  # Should match the compose service name
             f"--db-type={args.db_type}",  # Add the selected database type
-            f"--no-mariadb-socket",
+            f"--mariadb-user-host-login-scope=%",
             f"--db-root-password=123",  # Replace with your MariaDB password
             f"--admin-password={args.admin_password}",
         ]


### PR DESCRIPTION
--no-mariadb-socket is DEPRECATED; use --mariadb-user-host-login-scope='%' (wildcard) or --mariadb-user-host-login-scope=<myhostscope>, instead.