### PR TITLE
fix: pwd SocketIO Origin in nginx conf

### DIFF
--- a/resources/nginx-template.conf
+++ b/resources/nginx-template.conf
@@ -39,7 +39,7 @@ server {
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "upgrade";
 		proxy_set_header X-Frappe-Site-Name ${FRAPPE_SITE_NAME_HEADER};
-		proxy_set_header Origin $scheme://${FRAPPE_SITE_NAME_HEADER};
+		proxy_set_header Origin $scheme://$http_host;
 		proxy_set_header Host $host;
 
 		proxy_pass http://socketio-server;


### PR DESCRIPTION
This was not EASY. Don't judge by the diff. This fix comes after hours and hours of calls with @revant 😅