### PR TITLE
Remove redis-cache volume

### DIFF
--- a/docs/setup_for_linux_mac.md
+++ b/docs/setup_for_linux_mac.md
@@ -175,8 +175,6 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    volumes:
-      - redis-cache-data:/data
 
   scheduler:
     image: frappe/erpnext:v15
@@ -207,7 +205,6 @@ services:
 volumes:
   db-data:
   redis-queue-data:
-  redis-cache-data:
   sites:
   logs:
 ```

--- a/overrides/compose.redis.yaml
+++ b/overrides/compose.redis.yaml
@@ -9,8 +9,6 @@ services:
 
   redis-cache:
     image: redis:6.2-alpine
-    volumes:
-      - redis-cache-data:/data
 
   redis-queue:
     image: redis:6.2-alpine
@@ -18,5 +16,4 @@ services:
       - redis-queue-data:/data
 
 volumes:
-  redis-cache-data:
   redis-queue-data:

--- a/overrides/compose.traefik-ssl.yaml
+++ b/overrides/compose.traefik-ssl.yaml
@@ -2,7 +2,7 @@ services:
   traefik:
     labels:
       # https-redirect middleware to redirect HTTP to HTTPS
-      # It can be re-used by other stacks in other Docker Compose files
+      # It can be reused by other stacks in other Docker Compose files
       - traefik.http.middlewares.https-redirect.redirectscheme.scheme=https
       - traefik.http.middlewares.https-redirect.redirectscheme.permanent=true
       # traefik-http to use the middleware to redirect to https

--- a/pwd.yml
+++ b/pwd.yml
@@ -176,8 +176,6 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    volumes:
-      - redis-cache-data:/data
 
   scheduler:
     image: frappe/erpnext:v15.49.3
@@ -210,7 +208,6 @@ services:
 volumes:
   db-data:
   redis-queue-data:
-  redis-cache-data:
   sites:
   logs:
 


### PR DESCRIPTION
### Details of the Change:

This pull request addresses an issue where the assets.json file, now stored in Redis by Frappe, persists across new image builds due to the Redis cache volume being persistent. This prevents updates to assets.json from being reflected after a new build.

The proposed change removes the persistent volume for redis-cache, ensuring that the cache, including assets.json, is cleared during each new image deployment.

### Problem Solved:

By removing the persistent Redis volume, we prevent outdated assets.json data from being retained, ensuring the application always works with the latest assets after a build. This eliminates the need for manual intervention or additional automation to clear the cache.

Retaining the old assets.json file will cause the websites to miss certain assets:

![image](https://github.com/user-attachments/assets/2eb6b3ec-ed6a-4ac2-b72e-cabbae0669cc)

### Why is This Necessary?

Without this change, developers or pipelines must manually clear the assets.json value from Redis or automate the process using additional scripts or hooks. Removing the persistent volume simplifies the process and avoids potential misconfigurations.

This PR was inspired by @ankush's comment on the issue https://github.com/frappe/frappe/issues/29901 , as he correctly pointed out that there is no need to persist in this volume.
