### PR TITLE
Compose with restart

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,7 @@ x-customizable-image: &customizable_image
   # about using custom images.
   image: ${CUSTOM_IMAGE:-frappe/erpnext}:${CUSTOM_TAG:-$ERPNEXT_VERSION}
   pull_policy: ${PULL_POLICY:-always}
+  restart: ${RESTART_POLICY:-unless-stopped}
 
 x-depends-on-configurator: &depends_on_configurator
   depends_on:
@@ -39,6 +40,7 @@ services:
       REDIS_QUEUE: ${REDIS_QUEUE:-}
       SOCKETIO_PORT: 9000
     depends_on: {}
+    restart: no
 
   backend:
     <<: *backend_defaults

--- a/compose.yaml
+++ b/compose.yaml
@@ -40,7 +40,7 @@ services:
       REDIS_QUEUE: ${REDIS_QUEUE:-}
       SOCKETIO_PORT: 9000
     depends_on: {}
-    restart: no
+    restart: on-failure
 
   backend:
     <<: *backend_defaults

--- a/overrides/compose.https.yaml
+++ b/overrides/compose.https.yaml
@@ -9,6 +9,7 @@ services:
 
   proxy:
     image: traefik:v2.11
+    restart: unless-stopped
     command:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false

--- a/overrides/compose.mariadb.yaml
+++ b/overrides/compose.mariadb.yaml
@@ -13,6 +13,7 @@ services:
       test: mysqladmin ping -h localhost --password=${DB_PASSWORD}
       interval: 1s
       retries: 20
+    restart: unless-stopped
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci

--- a/overrides/compose.redis.yaml
+++ b/overrides/compose.redis.yaml
@@ -9,9 +9,11 @@ services:
 
   redis-cache:
     image: redis:6.2-alpine
+    restart: unless-stopped
 
   redis-queue:
     image: redis:6.2-alpine
+    restart: unless-stopped
     volumes:
       - redis-queue-data:/data
 


### PR DESCRIPTION
Addes restart policy to compose.yaml

Futhermore added restart policy to overriders:

- overrides/compose.mariadb.yaml
- overrides/compose.redis.yaml
- overrides/compose.https.yaml

Resolves #1562

