### PR TITLE
Fix Make frontend and backend containers listen on both IPv4 and IPv6

### DIFF
--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -147,7 +147,7 @@ VOLUME [ \
 CMD [ \
   "/home/frappe/frappe-bench/env/bin/gunicorn", \
   "--chdir=/home/frappe/frappe-bench/sites", \
-  "--bind=0.0.0.0:8000", \
+  "--bind=[::]:8000", \
   "--threads=4", \
   "--workers=2", \
   "--worker-class=gthread", \

--- a/images/layered/Containerfile
+++ b/images/layered/Containerfile
@@ -47,7 +47,7 @@ VOLUME [ \
 CMD [ \
   "/home/frappe/frappe-bench/env/bin/gunicorn", \
   "--chdir=/home/frappe/frappe-bench/sites", \
-  "--bind=0.0.0.0:8000", \
+  "--bind=[::]:8000", \
   "--threads=4", \
   "--workers=2", \
   "--worker-class=gthread", \

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -136,7 +136,7 @@ VOLUME [ \
 CMD [ \
   "/home/frappe/frappe-bench/env/bin/gunicorn", \
   "--chdir=/home/frappe/frappe-bench/sites", \
-  "--bind=0.0.0.0:8000", \
+  "--bind=[::]:8000", \
   "--threads=4", \
   "--workers=2", \
   "--worker-class=gthread", \

--- a/resources/nginx-template.conf
+++ b/resources/nginx-template.conf
@@ -8,6 +8,8 @@ upstream socketio-server {
 
 server {
 	listen 8080;
+	listen [::]:8080;
+	
 	server_name ${FRAPPE_SITE_NAME_HEADER};
 	root /home/frappe/frappe-bench/sites;
 


### PR DESCRIPTION
With the release of docker v28 it is now possible to have IPv6 only networks but the containers right now don't support/listen on IPv6 interfaces.

This PR makes it so they listen on both IPv4 and IPv6 interfaces.