### PR TITLE
doc: Clarify development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -221,6 +221,11 @@ bench --site development.localhost install-app erpnext
 ```
 
 Note: Both frappe and erpnext must be on branch with same name. e.g. version-14
+You can use the `switch-to-branch` command to align versions if you get an error about mismatching versions.
+
+```shell
+bench switch-to-branch version-xx
+```
 
 ### Start Frappe without debugging
 


### PR DESCRIPTION
Clarify documentation about error.

I was following along the development doc to start creating a new custom app.

I faced this error with no apparent solution:
![image](https://github.com/user-attachments/assets/0ef9713f-e1e5-489c-bc26-51531f1a24ee)


Searching for the message error I found this at discuss: https://discuss.frappe.io/t/youre-attempting-to-install-erpnext-version-15-with-frappe-version-16-this-is-not-supported-and-wi/127422