### PR TITLE
Emails are not sent automatically due to Long Queue and Short Queue containers are Exited

### DIFF
--- a/.github/workflows/build_custom_image.yml
+++ b/.github/workflows/build_custom_image.yml
@@ -1,0 +1,70 @@
+name: Build and Push Custom Frappe Docker Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout frappe_docker repository
+      uses: actions/checkout@v3
+      with:
+        repository: frappe/frappe_docker
+
+    - name: Create apps.json
+      run: |
+        cat <<EOF > apps.json
+        [
+          {
+            "url": "https://github.com/frappe/erpnext",
+            "branch": "version-15"
+          },
+          {
+            "url": "https://github.com/frappe/hrms",
+            "branch": "version-15"
+          },
+          {
+            "url": "https://github.com/frappe/helpdesk",
+            "branch": "develop"
+          }
+          {
+            "url": "https://github.com/resilient-tech/india-compliance",
+            "branch": "version-15"
+          }
+        ]
+        EOF
+
+    - name: Check apps.json syntax
+      run: jq empty apps.json
+
+    - name: Generate APPS_JSON_BASE64
+      run: |
+        export APPS_JSON_BASE64=$(base64 -w 0 apps.json)
+        echo "APPS_JSON_BASE64=$APPS_JSON_BASE64" >> $GITHUB_ENV
+
+    - name: Install podman
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y podman
+
+    - name: Build custom image
+      run: |
+        podman build \
+          --build-arg=FRAPPE_PATH=https://github.com/frappe/frappe \
+          --build-arg=FRAPPE_BRANCH=version-15 \
+          --build-arg=APPS_JSON_BASE64=${{ env.APPS_JSON_BASE64 }} \
+          --tag=ghcr.io/${{ github.repository }}/custom:15 \
+          --file=images/layered/Containerfile .
+
+    - name: Podman login to ghcr.io
+      run: |
+        podman login ghcr.io -u ${{ github.actor }} -p ${{ secrets.USER_TOKEN }}
+
+    - name: Push image to ghcr.io
+      run: |
+        podman push ghcr.io/${{ github.repository }}/custom:15
+
+    - name: podman images list
+      run: podman images

--- a/.github/workflows/build_custom_image.yml
+++ b/.github/workflows/build_custom_image.yml
@@ -28,7 +28,7 @@ jobs:
           {
             "url": "https://github.com/frappe/helpdesk",
             "branch": "develop"
-          }
+          },
           {
             "url": "https://github.com/resilient-tech/india-compliance",
             "branch": "version-15"
@@ -37,7 +37,9 @@ jobs:
         EOF
 
     - name: Check apps.json syntax
-      run: jq empty apps.json
+      run: |
+        cat apps.json
+        jq empty apps.json
 
     - name: Generate APPS_JSON_BASE64
       run: |
@@ -60,7 +62,7 @@ jobs:
 
     - name: Podman login to ghcr.io
       run: |
-        podman login ghcr.io -u ${{ github.actor }} -p ${{ secrets.USER_TOKEN }}
+        podman login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push image to ghcr.io
       run: |

--- a/pwd.yml
+++ b/pwd.yml
@@ -142,6 +142,8 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs
+    depends_on:
+      - redis-queue
 
   queue-short:
     image: frappe/erpnext:v15.57.0
@@ -158,6 +160,8 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs
+    depends_on:
+      - redis-queue
 
   redis-queue:
     image: redis:6.2-alpine


### PR DESCRIPTION
Fix: Ensure Background Workers Start After Redis for Reliable Email Sending

**Please provide enough information so that others can review your pull request:**

This pull request addresses an issue where emails were not being sent automatically in the Frappe instance. Investigation revealed that the `queue-long` and `queue-short` Docker containers, responsible for processing background jobs including email sending, were exiting with a `redis.exceptions.ConnectionError`. This occurred because these worker containers were attempting to connect to the Redis queue service (`redis-queue`) before the Redis container had fully started and was available for connections.

**Explain the details for making this change. What existing problem does the pull request solve?**

This pull request introduces explicit dependency management in the `docker-compose.yml` file to ensure the correct startup order of the Docker containers. Specifically, the `depends_on` directive has been added to the `queue-long` and `queue-short` service definitions:

```yaml
  queue-long:
    # ... other configurations ...
    depends_on:
      - redis-queue

  queue-short:
    # ... other configurations ...
    depends_on:
      - redis-queue