### PR TITLE
chore: Update vscode-example scripts

### DIFF
--- a/development/vscode-example/launch.json
+++ b/development/vscode-example/launch.json
@@ -6,7 +6,7 @@
   "configurations": [
     {
       "name": "Bench Web",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/frappe-bench/apps/frappe/frappe/utils/bench_helper.py",
       "args": [
@@ -24,7 +24,7 @@
     },
     {
       "name": "Bench Short Worker",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/frappe-bench/apps/frappe/frappe/utils/bench_helper.py",
       "args": ["frappe", "worker", "--queue", "short"],
@@ -35,7 +35,7 @@
     },
     {
       "name": "Bench Long Worker",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/frappe-bench/apps/frappe/frappe/utils/bench_helper.py",
       "args": ["frappe", "worker", "--queue", "long"],
@@ -46,7 +46,7 @@
     },
     {
       "name": "Honcho SocketIO Watch Schedule Worker",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "/home/frappe/.local/bin/honcho",
       "cwd": "${workspaceFolder}/frappe-bench",

--- a/development/vscode-example/launch.json
+++ b/development/vscode-example/launch.json
@@ -52,13 +52,7 @@
       "program": "/home/frappe/.local/bin/honcho",
       "cwd": "${workspaceFolder}/frappe-bench",
       "console": "internalConsole",
-      "args": [
-        "start",
-        "socketio",
-        "watch",
-        "schedule",
-        "worker"
-      ],
+      "args": ["start", "socketio", "watch", "schedule", "worker"],
       "postDebugTask": "Clean Honcho SocketIO Watch Schedule Worker"
     }
   ],

--- a/development/vscode-example/launch.json
+++ b/development/vscode-example/launch.json
@@ -66,10 +66,7 @@
   "compounds": [
     {
       "name": "Honcho + Web debug",
-      "configurations": [
-        "Bench Web",
-        "Honcho SocketIO Watch Schedule Worker"
-      ],
+      "configurations": ["Bench Web", "Honcho SocketIO Watch Schedule Worker"],
       "stopAll": true
     }
   ]

--- a/development/vscode-example/launch.json
+++ b/development/vscode-example/launch.json
@@ -62,5 +62,15 @@
       ],
       "postDebugTask": "Clean Honcho SocketIO Watch Schedule Worker"
     }
+  ],
+  "compounds": [
+    {
+      "name": "Honcho + Web debug",
+      "configurations": [
+        "Bench Web",
+        "Honcho SocketIO Watch Schedule Worker"
+      ],
+      "stopAll": true
+    }
   ]
 }

--- a/development/vscode-example/launch.json
+++ b/development/vscode-example/launch.json
@@ -17,7 +17,6 @@
         "--noreload",
         "--nothreading"
       ],
-      "pythonPath": "${workspaceFolder}/frappe-bench/env/bin/python",
       "cwd": "${workspaceFolder}/frappe-bench/sites",
       "env": {
         "DEV_SERVER": "1"
@@ -29,7 +28,6 @@
       "request": "launch",
       "program": "${workspaceFolder}/frappe-bench/apps/frappe/frappe/utils/bench_helper.py",
       "args": ["frappe", "worker", "--queue", "short"],
-      "pythonPath": "${workspaceFolder}/frappe-bench/env/bin/python",
       "cwd": "${workspaceFolder}/frappe-bench/sites",
       "env": {
         "DEV_SERVER": "1"
@@ -41,7 +39,6 @@
       "request": "launch",
       "program": "${workspaceFolder}/frappe-bench/apps/frappe/frappe/utils/bench_helper.py",
       "args": ["frappe", "worker", "--queue", "long"],
-      "pythonPath": "${workspaceFolder}/frappe-bench/env/bin/python",
       "cwd": "${workspaceFolder}/frappe-bench/sites",
       "env": {
         "DEV_SERVER": "1"
@@ -52,7 +49,6 @@
       "type": "python",
       "request": "launch",
       "program": "/home/frappe/.local/bin/honcho",
-      "pythonPath": "${workspaceFolder}/frappe-bench/env/bin/python",
       "cwd": "${workspaceFolder}/frappe-bench",
       "console": "internalConsole",
       "args": [

--- a/development/vscode-example/launch.json
+++ b/development/vscode-example/launch.json
@@ -48,6 +48,7 @@
       "name": "Honcho SocketIO Watch Schedule Worker",
       "type": "debugpy",
       "request": "launch",
+      "python": "/home/frappe/.pyenv/shims/python",
       "program": "/home/frappe/.local/bin/honcho",
       "cwd": "${workspaceFolder}/frappe-bench",
       "console": "internalConsole",
@@ -56,9 +57,7 @@
         "socketio",
         "watch",
         "schedule",
-        "worker_short",
-        "worker_long",
-        "worker_default"
+        "worker"
       ],
       "postDebugTask": "Clean Honcho SocketIO Watch Schedule Worker"
     }

--- a/development/vscode-example/launch.json
+++ b/development/vscode-example/launch.json
@@ -59,7 +59,8 @@
         "worker_short",
         "worker_long",
         "worker_default"
-      ]
+      ],
+      "postDebugTask": "Clean Honcho SocketIO Watch Schedule Worker"
     }
   ]
 }

--- a/development/vscode-example/tasks.json
+++ b/development/vscode-example/tasks.json
@@ -1,22 +1,22 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "Clean Honcho SocketIO Watch Schedule Worker",
-            "detail": "When stopping the debug process from vscode window, the honcho won't receive the SIGINT signal. This task will send the SIGINT signal to the honcho processes.",
-            "type": "shell",
-            "command": "pkill -SIGINT -f bench; pkill -SIGINT -f socketio",
-            "isBackground": false,
-            "presentation": {
-                "echo": true,
-                "reveal": "silent",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "close": true
-            }
-        }
-    ]
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Clean Honcho SocketIO Watch Schedule Worker",
+      "detail": "When stopping the debug process from vscode window, the honcho won't receive the SIGINT signal. This task will send the SIGINT signal to the honcho processes.",
+      "type": "shell",
+      "command": "pkill -SIGINT -f bench; pkill -SIGINT -f socketio",
+      "isBackground": false,
+      "presentation": {
+        "echo": true,
+        "reveal": "silent",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "close": true
+      }
+    }
+  ]
 }

--- a/development/vscode-example/tasks.json
+++ b/development/vscode-example/tasks.json
@@ -1,0 +1,22 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Clean Honcho SocketIO Watch Schedule Worker",
+            "detail": "When stopping the debug process from vscode window, the honcho won't receive the SIGINT signal. This task will send the SIGINT signal to the honcho processes.",
+            "type": "shell",
+            "command": "pkill -SIGINT -f bench; pkill -SIGINT -f socketio",
+            "isBackground": false,
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "close": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

# Problem

When running the debug on vscode, if I stop it through the UI, the honcho process won't properly receive the SIGINT (Ctrl+C) to be finished.

![image](https://github.com/user-attachments/assets/d4109286-5e52-476f-bb89-a5c99db30ec9)

The second time you try to run it, the port `9000` will still be in use because of the not finished processes and you'd have to restart the container. That was really annoying.

<details><summary>Details</summary>
<p>

```shell
18:49:57 system           | socketio.1 started (pid=370139)
18:49:58 socketio.1       | node:events:495
18:49:58 socketio.1       |       throw er; // Unhandled 'error' event
18:49:58 socketio.1       |       ^
18:49:58 socketio.1       | 
18:49:58 socketio.1       | Error: listen EADDRINUSE: address already in use :::9000
18:49:58 socketio.1       |     at Server.setupListenHandle [as _listen2] (node:net:1817:16)
18:49:58 socketio.1       |     at listenInCluster (node:net:1865:12)
18:49:58 socketio.1       |     at Server.listen (node:net:1953:7)
18:49:58 socketio.1       |     at Object.<anonymous> (/workspace/development/frappe-bench/apps/frappe/realtime/index.js:63:8)
18:49:58 socketio.1       |     at Module._compile (node:internal/modules/cjs/loader:1256:14)
18:49:58 socketio.1       |     at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
18:49:58 socketio.1       |     at Module.load (node:internal/modules/cjs/loader:1119:32)
18:49:58 socketio.1       |     at Module._load (node:internal/modules/cjs/loader:960:12)
18:49:58 socketio.1       |     at Module.require (node:internal/modules/cjs/loader:1143:19)
18:49:58 socketio.1       |     at require (node:internal/modules/cjs/helpers:119:18)
18:49:58 socketio.1       | Emitted 'error' event on Server instance at:
18:49:58 socketio.1       |     at emitErrorNT (node:net:1844:8)
18:49:58 socketio.1       |     at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
18:49:58 socketio.1       |   code: 'EADDRINUSE',
18:49:58 socketio.1       |   errno: -98,
18:49:58 socketio.1       |   syscall: 'listen',
18:49:58 socketio.1       |   address: '::',
18:49:58 socketio.1       |   port: 9000
18:49:58 socketio.1       | }
18:49:58 socketio.1       | 
18:49:58 socketio.1       | Node.js v18.18.2
18:49:58 system           | socketio.1 stopped (rc=1)
18:49:58 system           | watch.1 started (pid=370188)
18:49:58 system           | schedule.1 started (pid=370216)
18:49:58 watch.1          | 
18:49:59 watch.1          | yarn run v1.22.22
18:49:59 watch.1          | $ node esbuild --watch --live-reload
18:49:59 system           | worker_long.1 started (pid=370260)
18:49:59 system           | worker_short.1 started (pid=370285)
18:49:59 system           | schedule.1 stopped (rc=0)
18:50:00 system           | worker_default.1 started (pid=370334)
18:50:00 system           | sending SIGTERM to watch.1 (pid 370188)
18:50:00 system           | sending SIGTERM to worker_short.1 (pid 370285)
18:50:00 system           | sending SIGTERM to worker_long.1 (pid 370260)
18:50:00 system           | sending SIGTERM to worker_default.1 (pid 370334)
18:50:00 system           | worker_short.1 stopped (rc=-15)
18:50:00 system           | worker_long.1 stopped (rc=-15)
18:50:00 system           | worker_default.1 stopped (rc=-15)
18:50:00 system           | watch.1 stopped (rc=-15)
``` 

</p>
</details> 


I've tried many things, the easiest that I found was running a `pkill` command to find the hanging processes inside the container.

Thus, I created a task to make it easier to call after stopping the debug launch.


## Other fixes on `launch.json`

### Outdated `type`: use `debugpy` instead of `python`

![image](https://github.com/user-attachments/assets/2b571b04-5fb6-41cb-9666-bb40058e7e00)

### Remove `pythonPath` as it is not allowed and redundant with `settings.json`

![image](https://github.com/user-attachments/assets/ef72c66a-3e4e-44ce-8438-4b364527c19b)

## Extra change

### Add a new compound setting to launch both web and honcho since this is very common to be used.

![image](https://github.com/user-attachments/assets/e97e7fc6-8f6e-4c73-bfd3-2d9454339461)
