### PR TITLE
fix(docker-compose - pwd.yml): prepend redis:// schema to REDIS_CACHE and REDIS_QUEUE

### DIFF
--- a/pwd.yml
+++ b/pwd.yml
@@ -39,8 +39,8 @@ services:
     environment:
       DB_HOST: db
       DB_PORT: "3306"
-      REDIS_CACHE: redis-cache:6379
-      REDIS_QUEUE: redis-queue:6379
+      REDIS_CACHE: redis://redis-cache:6379
+      REDIS_QUEUE: redis://redis-queue:6379 
       SOCKETIO_PORT: "9000"
     volumes:
       - sites:/home/frappe/frappe-bench/sites


### PR DESCRIPTION
Previously, the docker-compose.yml defined the Redis connection endpoints as bare host:port (redis-cache:6379, redis-queue:6379). Many Redis client libraries expect a full URI (redis://host:port) and will either error out or fall back to defaults if the scheme is missing.

This change updates the two environment variables to include the redis:// prefix so that the connection strings are parsed correctly.

Explain the details for making this change. What existing problem does the pull request solve?

The application’s task queue and cache layers read connection URLs from REDIS_QUEUE and REDIS_CACHE. Without the URI scheme, clients were unable to parse the host and port properly, resulting in runtime connection failures. By explicitly adding redis:// in the compose file, we ensure:
	1.	Correct parsing of host and port by all Redis clients.
	2.	Avoidance of subtle errors that only manifest when the service is restarted or redeployed under Docker Swarm.

Fixes error message from "queue-short":

Please make sure that Redis Queue runs @ redis://. Redis reported error: Error 111 connecting to localhost:6379. Connection refused.