### PR TITLE
Add WEB_CONCURRENCY=8 to devcontainer example for improved performance

### DIFF
--- a/devcontainer-example/docker-compose.yml
+++ b/devcontainer-example/docker-compose.yml
@@ -50,6 +50,7 @@ services:
     command: sleep infinity
     environment:
       - SHELL=/bin/bash
+      - WEB_CONCURRENCY=8
     volumes:
       - ..:/workspace:cached
       # Enable if you require git cloning


### PR DESCRIPTION
### Summary

This PR updates the `devcontainer-example/docker-compose.yml` to include:

```yaml
environment:
  - WEB_CONCURRENCY=8
```
I observed that ERPNext’s performance under concurrent API load can be improved by increasing the number of Gunicorn worker processes. 

I tested this by pinging the `/api/method/ping` endpoint  that sends 20 concurrent requests via `curl`. I ran this test multiple times — first with 1 worker, and then another with 8. 

I found that the average time was

- WEB_CONCURRENCY=1: 275 ms
- WEB_CONCURRENCY=8: 237 ms.

Although the endpoint is lightweight, the higher concurrency setting resulted in faster overall response time. 

### Conclusion

By including WEB_CONCURRENCY=8, developers get a more realistic performance profile when testing ERPNext APIs or load-sensitive features.

### Notes
- This change is scoped only to the DevContainer example and has no impact on production or Docker image builds.
- Happy to revise the worker count or move this config to documentation if preferred by maintainers.




