### PR TITLE
chore: remove deprecated version directive

### DIFF
--- a/devcontainer-example/docker-compose.yml
+++ b/devcontainer-example/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   mariadb:
     image: docker.io/mariadb:10.6

--- a/docs/backup-and-push-cronjob.md
+++ b/docs/backup-and-push-cronjob.md
@@ -2,7 +2,6 @@ Create backup service or stack.
 
 ```yaml
 # backup-job.yml
-version: "3.7"
 services:
   backup:
     image: frappe/erpnext:${VERSION}

--- a/docs/setup_for_linux_mac.md
+++ b/docs/setup_for_linux_mac.md
@@ -11,8 +11,6 @@ step2: add platform: linux/amd64 to all services in the /pwd.yaml
 here is the update pwd.yml file
 
 ```yml
-version: "3"
-
 services:
   backend:
     image: frappe/erpnext:v15

--- a/overrides/compose.custom-domain.yaml
+++ b/overrides/compose.custom-domain.yaml
@@ -1,5 +1,3 @@
-version: "3.3"
-
 services:
   custom-domain:
     image: caddy:2

--- a/overrides/compose.mariadb-shared.yaml
+++ b/overrides/compose.mariadb-shared.yaml
@@ -1,5 +1,3 @@
-version: "3.3"
-
 services:
   database:
     container_name: mariadb-database

--- a/overrides/compose.traefik.yaml
+++ b/overrides/compose.traefik.yaml
@@ -1,5 +1,3 @@
-version: "3.3"
-
 services:
   traefik:
     image: "traefik:v2.11"

--- a/pwd.yml
+++ b/pwd.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   backend:
     image: frappe/erpnext:v15.63.0


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

This removes the deprecated `version` directive from compose files.

> Explain the **details** for making this change. What existing problem does the pull request solve?

The `version` directive is deprecated as indicated by the couple error messages generated when using these files:

> WARN[0000] /home/erp/frappe_docker/overrides/compose.traefik.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

I'm submitting this mainly to clean up the output of the commands using these files and make it easier to see other more important warnings or error messages.