### PR TITLE
Add restart to backup cron

### DIFF
--- a/overrides/compose.backup-cron.yaml
+++ b/overrides/compose.backup-cron.yaml
@@ -3,6 +3,7 @@ services:
     image: mcuadros/ofelia:latest
     depends_on:
       - scheduler
+    restart: unless-stopped
     command: daemon --docker
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Make sure backups don't stop happening following something like a docker update.

> Explain the **details** for making this change. What existing problem does the pull request solve?

Makes it so the cron container keeps running after a restart.