### PR TITLE
chore: Add configuration for Bench Default Worker in launch.json

### DIFF
--- a/development/vscode-example/launch.json
+++ b/development/vscode-example/launch.json
@@ -38,12 +38,7 @@
       "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/frappe-bench/apps/frappe/frappe/utils/bench_helper.py",
-      "args": [
-        "frappe",
-        "worker",
-        "--queue",
-        "default"
-      ],
+      "args": ["frappe", "worker", "--queue", "default"],
       "cwd": "${workspaceFolder}/frappe-bench/sites",
       "env": {
         "DEV_SERVER": "1"


### PR DESCRIPTION
Include the configuration for the Bench Default Worker in launch.json: https://github.com/frappe/frappe/blob/82f0cc1d09115e84d6acb37fb2b010b2aba69bfc/frappe/__init__.py#L2231