### PR TITLE
Update Install Traefik Section

### DIFF
--- a/docs/single-server-example.md
+++ b/docs/single-server-example.md
@@ -65,7 +65,7 @@ Create a file called `traefik.env` in `~/gitops`
 ```shell
 echo 'TRAEFIK_DOMAIN=traefik.example.com' > ~/gitops/traefik.env
 echo 'EMAIL=admin@example.com' >> ~/gitops/traefik.env
-echo 'HASHED_PASSWORD='$(openssl passwd -apr1 changeit | sed -e s/\\$/\\$\\$/g) >> ~/gitops/traefik.env
+echo "HASHED_PASSWORD='$(openssl passwd -apr1 changeit)'" >> ~/gitops/traefik.env
 ```
 
 Note:


### PR DESCRIPTION
Since the password would be parsed in single quote (') the text transformation is no longer needed. This update is based on issue #1002 (Unable to login to Traefik Dashboard even after providing Correct password in Basic Auth.)