### PR TITLE
Add extra detail to line 33 of README.md to improve user accessibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then run: `docker compose -f pwd.yml up -d`
 
 ### To run on ARM64 architecture follow this instructions
 
-After cloning the repo run this command to build multi-architecture images specifically for ARM64.
+After you clone the repo and `cd frappe_docker`, run this command to build multi-architecture images specifically for ARM64.
 
 `docker buildx bake --no-cache --set "*.platform=linux/arm64"`
 


### PR DESCRIPTION
The instructions currently say "After cloning the repo run this command to build multi-architecture images specifically for ARM64."

It would improve accessibility to change it to "After you clone the repo and cd frappe_docker, run this command to build multi-architecture images specifically for ARM64."

Thank you for building the instructions!