### PR TITLE
Improve devcontainer behaviour on ARM Macs

### DIFF
--- a/devcontainer-example/docker-compose.yml
+++ b/devcontainer-example/docker-compose.yml
@@ -42,8 +42,7 @@ services:
     image: docker.io/redis:alpine
 
   frappe:
-    image: docker.io/frappe/bench:latest
-    platform: linux/amd64
+    build: ../images/bench
     command: sleep infinity
     environment:
       - SHELL=/bin/bash

--- a/devcontainer-example/docker-compose.yml
+++ b/devcontainer-example/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3.7"
 services:
   mariadb:
     image: docker.io/mariadb:10.6
-    platform: linux/amd64
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
@@ -38,11 +37,9 @@ services:
 
   redis-cache:
     image: docker.io/redis:alpine
-    platform: linux/amd64
 
   redis-queue:
     image: docker.io/redis:alpine
-    platform: linux/amd64
 
   frappe:
     image: docker.io/frappe/bench:latest


### PR DESCRIPTION
We discovered that the devcontainer experience is subobtimal on ARM Macs. I think these are very popular and maybe even Windows or Linux builds with ARM CPU's will someday be useful ;).

This change increased the performance of our local dev Setup significantly.