### PR TITLE
Revert "Use `docker compose` instead of `docker-compose`"

### DIFF
--- a/docs/site-operations.md
+++ b/docs/site-operations.md
@@ -1,16 +1,16 @@
 # Site operations
 
-> 💡 You should setup `--project-name` option in `docker` commands if you have non-standard project name.
+> 💡 You should setup `--project-name` option in `docker-compose` commands if you have non-standard project name.
 
 ## Setup new site
 
 Note:
 
 - Wait for the `db` service to start and `configurator` to exit before trying to create a new site. Usually this takes up to 10 seconds.
-- Also you have to pass `-p <project_name>` if `-p` passed previously eg. `docker -p <project_name> exec (rest of the command)`.
+- Also you have to pass `-p <project_name>` if `-p` passed previously eg. `docker-compose -p <project_name> exec (rest of the command)`.
 
 ```sh
-docker exec backend bench new-site --mariadb-user-host-login-scope=% --db-root-password <db-password> --admin-password <admin-password> <site-name>
+docker-compose exec backend bench new-site --mariadb-user-host-login-scope=% --db-root-password <db-password> --admin-password <admin-password> <site-name>
 ```
 
 If you need to install some app, specify `--install-app`. To see all options, just run `bench new-site --help`.
@@ -18,14 +18,14 @@ If you need to install some app, specify `--install-app`. To see all options, ju
 To create Postgres site (assuming you already use [Postgres compose override](images-and-compose-files.md#overrides)) you need have to do set `root_login` and `root_password` in common config before that:
 
 ```sh
-docker exec backend bench set-config -g root_login <root-login>
-docker exec backend bench set-config -g root_password <root-password>
+docker-compose exec backend bench set-config -g root_login <root-login>
+docker-compose exec backend bench set-config -g root_password <root-password>
 ```
 
 Also command is slightly different:
 
 ```sh
-docker exec backend bench new-site --mariadb-user-host-login-scope=% --db-type postgres --admin-password <admin-password> <site-name>
+docker-compose exec backend bench new-site --mariadb-user-host-login-scope=% --db-type postgres --admin-password <admin-password> <site-name>
 ```
 
 ## Push backup to S3 storage
@@ -33,7 +33,7 @@ docker exec backend bench new-site --mariadb-user-host-login-scope=% --db-type p
 We have the script that helps to push latest backup to S3.
 
 ```sh
-docker exec backend push_backup.py --site-name <site-name> --bucket <bucket> --region-name <region> --endpoint-url <endpoint-url> --aws-access-key-id <access-key> --aws-secret-access-key <secret-key>
+docker-compose exec backend push_backup.py --site-name <site-name> --bucket <bucket> --region-name <region> --endpoint-url <endpoint-url> --aws-access-key-id <access-key> --aws-secret-access-key <secret-key>
 ```
 
 Note that you can restore backup only manually.
@@ -59,7 +59,7 @@ Instead of `alpine` use any image of your choice.
 For socketio and gunicorn service ping the hostname:port and that will be sufficient. For workers and scheduler, there is a command that needs to be executed.
 
 ```shell
-docker exec backend healthcheck.sh --ping-service mongodb:27017
+docker-compose exec backend healthcheck.sh --ping-service mongodb:27017
 ```
 
 Additional services can be pinged as part of health check with option `-p` or `--ping-service`.
@@ -72,7 +72,7 @@ If connection to service(s) fails, the command fails with exit code 1.
 For reference of commands like `backup`, `drop-site` or `migrate` check [official guide](https://frappeframework.com/docs/v13/user/en/bench/frappe-commands) or run:
 
 ```sh
-docker exec backend bench --help
+docker-compose exec backend bench --help
 ```
 
 ## Migrate site
@@ -82,5 +82,5 @@ Note:
 - Wait for the `db` service to start and `configurator` to exit before trying to migrate a site. Usually this takes up to 10 seconds.
 
 ```sh
-docker exec backend bench --site <site-name> migrate
+docker-compose exec backend bench --site <site-name> migrate
 ```


### PR DESCRIPTION
Reverts frappe/frappe_docker#1702 since the `-p` command is not available on the base `docker` command and is only available on the `docker compose` command.

Sorry for the confusion!