### PR TITLE
fix: mariadb-user-host-login-scope

### DIFF
--- a/overrides/compose.mariadb.yaml
+++ b/overrides/compose.mariadb.yaml
@@ -19,6 +19,7 @@ services:
       - --collation-server=utf8mb4_unicode_ci
       - --skip-character-set-client-handshake
       - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
+      - --mariadb-user-host-login-scope='172.%.%.%'
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD:-123}
     volumes:


### PR DESCRIPTION
# Problem:
By default, MariaDB does not allow connections from the backend container, since it runs in a separate container.

# Solution:
Added a scope to allow local machines to communicate with the database.