### PR TITLE
bugfix: add correct redis URLs to environment of other containers

### DIFF
--- a/pwd.yml
+++ b/pwd.yml
@@ -142,6 +142,9 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs
+    environment:
+      FRAPPE_REDIS_CACHE: redis://redis-cache:6379
+      FRAPPE_REDIS_QUEUE: redis://redis-queue:6379
 
   queue-short:
     image: frappe/erpnext:v15.82.0
@@ -158,6 +161,9 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs
+    environment:
+      FRAPPE_REDIS_CACHE: redis://redis-cache:6379
+      FRAPPE_REDIS_QUEUE: redis://redis-queue:6379
 
   redis-queue:
     image: redis:6.2-alpine
@@ -201,6 +207,9 @@ services:
     command:
       - node
       - /home/frappe/frappe-bench/apps/frappe/socketio.js
+    environment:
+      FRAPPE_REDIS_CACHE: redis://redis-cache:6379
+      FRAPPE_REDIS_QUEUE: redis://redis-queue:6379
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

This PR adds environment variables to some of the containers so that they don't try to connect to redis on 127.0.0.1, but instead connect to the redis containers.

> Explain the **details** for making this change. What existing problem does the pull request solve?

Fixes this issue that is encountered on a clean setup and renders the app unusable:
- https://github.com/frappe/frappe_docker/issues/1654#issuecomment-3380885254
