### PR TITLE
Changing type of DB_PORT to string

### DIFF
--- a/overrides/compose.mariadb.yaml
+++ b/overrides/compose.mariadb.yaml
@@ -2,7 +2,7 @@ services:
   configurator:
     environment:
       DB_HOST: db
-      DB_PORT: 3306
+      DB_PORT: "3306"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
A value for DB_PORT must be a string for the podman-compose to work.

> Please provide enough information so that others can review your pull request:
` podman-compose -f compose.yaml -f overrides/compose.mariadb.yaml -f overrides/compose.redis.yaml -f overrides/compose.noproxy.yaml config > ./docker-compose.yml
` fails because of the data type assigned to DB_PORT, this works fine for Docker Compose, but when following Podman Custom Apps installation guideline, this step won't work unless the value is changed to a string type. 

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

podman-compose shows the following error

```
raise ValueError(f"can't merge value of [{key}] of type {value_type} and {value2_type}")
ValueError: can't merge value of [DB_PORT] of type <class 'str'> and <class 'int'>
```
To fix this issue, the DB_PORT must be changed to a string type. 
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Adding double quotes will fix this issue. 