### PR TITLE
feat: added v16 docker images

### DIFF
--- a/.github/scripts/get_latest_tags.py
+++ b/.github/scripts/get_latest_tags.py
@@ -9,7 +9,7 @@ import sys
 from typing import Literal
 
 Repo = Literal["frappe", "erpnext"]
-MajorVersion = Literal["12", "13", "14", "15", "develop"]
+MajorVersion = Literal["12", "13", "14", "15", "16", "develop"]
 
 
 def get_latest_tag(repo: Repo, version: MajorVersion) -> str:
@@ -57,7 +57,7 @@ def main(_args: list[str]) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", choices=["frappe", "erpnext"], required=True)
     parser.add_argument(
-        "--version", choices=["12", "13", "14", "15", "develop"], required=True
+        "--version", choices=["12", "13", "14", "15", "16", "develop"], required=True
     )
     args = parser.parse_args(_args)
 

--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -54,6 +54,18 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
+  v16:
+    uses: ./.github/workflows/docker-build-push.yml
+    with:
+      repo: erpnext
+      version: "16"
+      push: ${{ github.repository == 'frappe/frappe_docker' && github.event_name != 'pull_request' }}
+      python_version: 3.12.12
+      node_version: 22.21.1
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
   update_versions:
     name: Update example.env and pwd.yml
     runs-on: ubuntu-latest


### PR DESCRIPTION
#1749 

Adds v16 images to the `build_stable` workflow which is called by `frappe/frappe` and `frappe/erpnext`