### PR TITLE
feat(devcontainer): Add mariadb driver and connection settings

### DIFF
--- a/devcontainer-example/devcontainer.json
+++ b/devcontainer-example/devcontainer.json
@@ -9,6 +9,7 @@
         "ms-vscode.live-server",
         "grapecity.gc-excelviewer",
         "mtxr.sqltools",
+        "mtxr.sqltools-driver-mysql",
         "visualstudioexptteam.vscodeintellicode"
       ],
       "settings": {
@@ -18,7 +19,24 @@
           }
         },
         "terminal.integrated.defaultProfile.linux": "frappe bash",
-        "debug.node.autoAttach": "disabled"
+        "debug.node.autoAttach": "disabled",
+        "sqltools.connections": [
+          {
+            "mysqlOptions": {
+              "authProtocol": "default",
+              "enableSsl": "Disabled"
+            },
+            "ssh": "Disabled",
+            "previewLimit": 50,
+            "server": "mariadb",
+            "port": 3306,
+            "driver": "MariaDB",
+            "name": "MariaDB",
+            "username": "root",
+            "password": "123",
+            "database": "mysql"
+          }
+        ]
       }
     }
   },


### PR DESCRIPTION
actually make use of the already installed sqltools

The Database connection will be added
<img width="616" height="504" alt="image" src="https://github.com/user-attachments/assets/12b8fc26-dcd4-4681-b24f-5b0d955a7f95" />
