### PR TITLE
Removed the `version` attribute from docker compose files

### DIFF
--- a/devcontainer-example/docker-compose.yml
+++ b/devcontainer-example/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   mariadb:
     image: docker.io/mariadb:11.8

--- a/overrides/compose.custom-domain.yaml
+++ b/overrides/compose.custom-domain.yaml
@@ -1,5 +1,3 @@
-version: "3.3"
-
 services:
   custom-domain:
     image: caddy:2

--- a/overrides/compose.mariadb-shared.yaml
+++ b/overrides/compose.mariadb-shared.yaml
@@ -1,5 +1,3 @@
-version: "3.3"
-
 services:
   database:
     container_name: mariadb-database

--- a/overrides/compose.traefik.yaml
+++ b/overrides/compose.traefik.yaml
@@ -1,5 +1,3 @@
-version: "3.3"
-
 services:
   traefik:
     image: "traefik:v2.11"

--- a/pwd.yml
+++ b/pwd.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   backend:
     image: frappe/erpnext:v15.92.0


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Removed the `version` attribute from docker compose files

> Explain the **details** for making this change. What existing problem does the pull request solve?

This will satisfy docker and remove the warning:
```
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

fix #1772