### PR TITLE
fix: MariaDB Authentication Issue with New Version of Docker Desktop

### DIFF
--- a/devcontainer-example/docker-compose.yml
+++ b/devcontainer-example/docker-compose.yml
@@ -6,11 +6,14 @@ services:
       - --collation-server=utf8mb4_unicode_ci
       - --skip-character-set-client-handshake
       - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
+      - --skip-name-resolve
     environment:
       MYSQL_ROOT_PASSWORD: 123
       MARIADB_AUTO_UPGRADE: 1
     volumes:
       - mariadb-data:/var/lib/mysql
+    networks:
+      - frappe-network
 
   # Enable PostgreSQL only if you use it, see development/README.md for more information.
   # postgresql:
@@ -34,12 +37,18 @@ services:
   #      MP_DATA_FILE: /data/mailpit.db
   #      MP_SMTP_AUTH_ACCEPT_ANY: 1
   #      MP_SMTP_AUTH_ALLOW_INSECURE: 1
+  #    networks:
+  #      - frappe-network
 
   redis-cache:
     image: docker.io/redis:alpine
+    networks:
+      - frappe-network
 
   redis-queue:
     image: docker.io/redis:alpine
+    networks:
+      - frappe-network
 
   frappe:
     image: docker.io/frappe/bench:latest
@@ -56,6 +65,8 @@ services:
     ports:
       - 8000-8005:8000-8005
       - 9000-9005:9000-9005
+    networks:
+      - frappe-network
   # enable the below service if you need Cypress UI Tests to be executed
   # Before enabling ensure install_x11_deps.sh has been executed and display variable is exported.
   # Run install_x11_deps.sh again if DISPLAY is not set
@@ -87,3 +98,6 @@ volumes:
   mariadb-data:
   #postgresql-data:
   #mailpit-data:
+networks:
+  frappe-network:
+    driver: bridge


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

This pull request addresses the error
```
pymysql.err.OperationalError: (1130, "Host '172.18.0.6' is not allowed to connect to this MariaDB server")
```

Which started showing up after updating Docker Desktop in Windows.

<details>
<summary>MariaDB Error Trace</summary>

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/workspace/kbmr-bench/apps/frappe/frappe/utils/bench_helper.py", line 114, in <module>
    main()
  File "/workspace/kbmr-bench/apps/frappe/frappe/utils/bench_helper.py", line 20, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/workspace/kbmr-bench/env/lib/python3.11/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/kbmr-bench/env/lib/python3.11/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/workspace/kbmr-bench/env/lib/python3.11/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/kbmr-bench/env/lib/python3.11/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/kbmr-bench/env/lib/python3.11/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/kbmr-bench/env/lib/python3.11/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/kbmr-bench/apps/frappe/frappe/commands/site.py", line 105, in new_site
    _new_site(
  File "/workspace/kbmr-bench/apps/frappe/frappe/installer.py", line 90, in _new_site
    install_db(
  File "/workspace/kbmr-bench/apps/frappe/frappe/installer.py", line 170, in install_db
    setup_database(force, verbose, mariadb_user_host_login_scope)
  File "/workspace/kbmr-bench/apps/frappe/frappe/database/__init__.py", line 21, in setup_database
    return frappe.database.mariadb.setup_db.setup_database(force, verbose, mariadb_user_host_login_scope)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/kbmr-bench/apps/frappe/frappe/database/mariadb/setup_db.py", line 33, in setup_database
    dbman.delete_user(db_name, **dbman_kwargs)
  File "/workspace/kbmr-bench/apps/frappe/frappe/database/db_manager.py", line 23, in delete_user
    self.db.sql(f"DROP USER IF EXISTS '{target}'@'{host}'")
  File "/workspace/kbmr-bench/apps/frappe/frappe/database/database.py", line 207, in sql
    self.connect()
  File "/workspace/kbmr-bench/apps/frappe/frappe/database/database.py", line 112, in connect
    self._conn: MariadbConnection | PostgresConnection = self.get_connection()
                                                         ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/kbmr-bench/apps/frappe/frappe/database/mariadb/database.py", line 108, in get_connection
    conn = self._get_connection()
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/kbmr-bench/apps/frappe/frappe/database/mariadb/database.py", line 114, in _get_connection
    return self.create_connection()
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/kbmr-bench/apps/frappe/frappe/database/mariadb/database.py", line 117, in create_connection
    return pymysql.connect(**self.get_connection_settings())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/kbmr-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 361, in __init__
    self.connect()
  File "/workspace/kbmr-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 668, in connect
    self._get_server_information()
  File "/workspace/kbmr-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 1098, in _get_server_information
    packet = self._read_packet()
             ^^^^^^^^^^^^^^^^^^^
  File "/workspace/kbmr-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 775, in _read_packet
    packet.raise_for_error()
  File "/workspace/kbmr-bench/env/lib/python3.11/site-packages/pymysql/protocol.py", line 219, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/workspace/kbmr-bench/env/lib/python3.11/site-packages/pymysql/err.py", line 150, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1130, "Host '172.18.0.6' is not allowed to connect to this MariaDB server")
```

</details>

> Explain the **details** for making this change. What existing problem does the pull request solve?

After updating the Docker Desktop for Windows to v4.55.0 MariaDB had an issue related to permission denied for connections from other containers. This commit resolves it by adding a dedicated network for all the containers in the compose, and adding a flag of MariaDB to avoid DNS resolution.

P.S: This may need more tests for users from other operating systems. But dedicated network is very much unlikely to cause any issues in the existing setup. Probably only an issue for users using Cypress for UI Tests