### PR TITLE
Update workflow to remove v14 and use v16

### DIFF
--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -30,18 +30,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  v14:
-    uses: ./.github/workflows/docker-build-push.yml
-    with:
-      repo: erpnext
-      version: "14"
-      push: ${{ github.repository == 'frappe/frappe_docker' && github.event_name != 'pull_request' }}
-      python_version: 3.10.13
-      node_version: 16.20.2
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-
   v15:
     uses: ./.github/workflows/docker-build-push.yml
     with:
@@ -70,7 +58,7 @@ jobs:
     name: Update example.env and pwd.yml
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'frappe/frappe_docker' && github.event_name != 'pull_request' }}
-    needs: v15
+    needs: v16
 
     steps:
       - name: Checkout
@@ -79,10 +67,10 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.14.2"
 
       - name: Get latest versions
-        run: python3 ./.github/scripts/get_latest_tags.py --repo erpnext --version 15
+        run: python3 ./.github/scripts/get_latest_tags.py --repo erpnext --version 16
 
       - name: Update
         run: |
@@ -108,7 +96,7 @@ jobs:
     name: Release Helm
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'frappe/frappe_docker' && github.event_name != 'pull_request' }}
-    needs: v15
+    needs: v16
 
     steps:
       - name: Setup deploy key


### PR DESCRIPTION
removes `v14` builds and sets `v16` as default in `pwd.yml` and `example.env`