### PR TITLE
fix: enable pnpm via corepack for apps that require it (e.g. drive)

### DIFF
--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -46,6 +46,7 @@ RUN useradd -ms /bin/bash frappe \
     && nvm install ${NODE_VERSION} \
     && nvm use v${NODE_VERSION} \
     && npm install -g yarn \
+    && corepack enable pnpm \
     && nvm alias default v${NODE_VERSION} \
     && rm -rf ${NVM_DIR}/.cache \
     && echo 'export NVM_DIR="/home/frappe/.nvm"' >>/home/frappe/.bashrc \

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -43,6 +43,7 @@ RUN useradd -ms /bin/bash frappe \
     && nvm install ${NODE_VERSION} \
     && nvm use v${NODE_VERSION} \
     && npm install -g yarn \
+    && corepack enable pnpm \
     && nvm alias default v${NODE_VERSION} \
     && rm -rf ${NVM_DIR}/.cache \
     && echo 'export NVM_DIR="/home/frappe/.nvm"' >>/home/frappe/.bashrc \


### PR DESCRIPTION
The drive app's frontend build runs `npm run check-pnpm && pnpm install
&& pnpm build`. In minimal Docker images, the non-root frappe user
cannot reliably `npm install -g pnpm`, so drive's install-pnpm.sh
silently fails and bench init aborts with exit code 127 during asset
building. I've made a PR their too so it doesn't silently fail, however that doesn't fix that there is not access to pnpm.

Enabling corepack in the base stage (where we still run as root) makes
pnpm available system-wide without requiring a separate global install.