### PR TITLE
fix: Add acme-companion nginx discovery label to nginx-proxy

### DIFF
--- a/overrides/compose.nginxproxy-ssl.yaml
+++ b/overrides/compose.nginxproxy-ssl.yaml
@@ -4,6 +4,8 @@ services:
       LETSENCRYPT_HOST: ${NGINX_PROXY_HOSTS:?No NGINX_PROXY_HOSTS set}
 
   nginx-proxy:
+    labels:
+      com.github.nginx-proxy.nginx: "true"
     ports:
       - ${HTTP_PUBLISH_PORT:-80}:80
       - ${HTTPS_PUBLISH_PORT:-443}:443


### PR DESCRIPTION
Closes #1813 

## Summary
Add the `com.github.nginx-proxy.nginx` label to the `nginx-proxy` service in the SSL override so `acme-companion` can reliably discover the proxy container during certificate operations and fixes the certificate generation.

Placing this in the SSL nginx override keeps the change scoped to the HTTPS/acme-companion setup.

## Changes
Added label `com.github.nginx-proxy.nginx: "true"`
