### PR TITLE
fix(nginx): forward correct proto/origin for socket.io behind proxy

### DIFF
--- a/resources/core/nginx/nginx-template.conf
+++ b/resources/core/nginx/nginx-template.conf
@@ -6,6 +6,12 @@ upstream socketio-server {
 	server ${SOCKETIO} fail_timeout=0;
 }
 
+# Parse the X-Forwarded-Proto header - if set - defaulting to $scheme.
+map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+	default $scheme;
+	https https;
+}
+
 server {
 	listen 8080;
 	server_name ${FRAPPE_SITE_NAME_HEADER};
@@ -36,10 +42,12 @@ server {
 
 	location /socket.io {
 		proxy_http_version 1.1;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "upgrade";
 		proxy_set_header X-Frappe-Site-Name ${FRAPPE_SITE_NAME_HEADER};
-		proxy_set_header Origin $scheme://$http_host;
+		proxy_set_header Origin $proxy_x_forwarded_proto://${FRAPPE_SITE_NAME_HEADER};
 		proxy_set_header Host $host;
 
 		proxy_pass http://socketio-server;


### PR DESCRIPTION
When running behind Traefik v3.6 with HTTPS, `$scheme` inside nginx is always `http` because Traefik terminates TLS. This caused the `Origin` header forwarded to the Socket.IO server to be `http://domain.com` instead of `https://domain.com`, resulting in a mismatch that silently dropped all real-time events to the browser.

Fixed by using `X-Forwarded-Proto` (set by Traefik) to correctly determine the actual client scheme when constructing the `Origin` header.