### PR TITLE
QueryDeadlockError (1020) on fresh Docker install with MariaDB 11 whe…

### DIFF
--- a/overrides/compose.mariadb.yaml
+++ b/overrides/compose.mariadb.yaml
@@ -21,6 +21,7 @@ services:
       - --collation-server=utf8mb4_unicode_ci
       - --skip-character-set-client-handshake
       - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
+      - --transaction-isolation=READ-COMMITTED
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD:-123}
       MARIADB_AUTO_UPGRADE: 1


### PR DESCRIPTION



```


Traceback with variables (most recent call last):
  File "apps/frappe/frappe/utils/background_jobs.py", line 225, in execute_job
    retval = method(**kwargs)
      site = 'fjnb'
      method = <function create_contact at 0x7f6170458e00>
      event = None
      job_name = 'frappe.core.doctype.user.user.create_contact'
      kwargs = {'user': <User: 1060778506@qq.com>, 'ignore_mandatory': True}
      user = '1060778506@qq.com'
      is_async = True
      retry = 0
      retval = None
      method_name = 'frappe.core.doctype.user.user.create_contact'
      before_job_task = 'frappe.monitor.start'
  File "apps/frappe/frappe/core/doctype/user/user.py", line 1257, in create_contact
    contact.insert(
      user = <User: 1060778506@qq.com>
      ignore_links = False
      ignore_mandatory = True
      get_contact_name = <function get_contact_name at 0x7f615dfb6c00>
      contact_name = None
      contact = <CustomContact: 丰茂德>
  File "apps/frappe/frappe/model/document.py", line 320, in insert
    self.db_insert(ignore_if_duplicate=ignore_if_duplicate)
      self = <CustomContact: 丰茂德>
      ignore_permissions = True
      ignore_links = False
      ignore_if_duplicate = False
      ignore_mandatory = True
      set_name = None
      set_child_names = True
  File "apps/frappe/frappe/model/base_document.py", line 576, in db_insert
    frappe.db.sql(
      self = <CustomContact: 丰茂德>
      ignore_if_duplicate = False
      conflict_handler = ''
      d = {'name': '丰茂德', 'owner': '1060778506@qq.com', 'creation': '2026-03-02 16:38:15.181717', 'modified': '2026-03-02 16:38:15.181717', 'modified_by': '1060778506@qq.com', 'docstatus': 0, 'idx': 0, 'first_name': '丰茂德', 'middle_name': None, 'last_name': '', 'full_name': '丰茂德', 'email_id': '1060778506@qq.com', 'user': '1060778506@qq.com', 'address': None, 'sync_with_google_contacts': 0, 'status': 'Passive', 'salutation': None, 'designation': None, 'gender': None, 'phone': '', 'mobile_no': '', 'company_name': None, 'image': '', 'google_contacts': None, 'google_contacts_id': None, 'pulled_from_google_contacts': 0, 'is_primary_contact': 0, 'is_billing_contact': 0, 'department': None, 'unsubscribed': 0}
      columns = ['name', 'owner', 'creation', 'modified', 'modified_by', 'docstatus', 'idx', 'first_name', 'middle_name', 'last_name', 'full_name', 'email_id', 'user', 'address', 'sync_with_google_contacts', 'status', 'salutation', 'designation', 'gender', 'phone', 'mobile_no', 'company_name', 'image', 'google_contacts', 'google_contacts_id', 'pulled_from_google_contacts', 'is_primary_contact', 'is_billing_contact', 'department', 'unsubscribed']
  File "apps/frappe/frappe/database/database.py", line 236, in sql
    raise frappe.QueryDeadlockError(e) from e
      self = <frappe.database.mariadb.database.MariaDBDatabase object at 0x7f617044ea90>
      query = 'INSERT INTO `tabContact` (`name`, `owner`, `creation`, `modified`, `modified_by`, `docstatus`, `idx`, `first_name`, `middle_name`, `last_name`, `full_name`, `email_id`, `user`, `address`, `sync_with_google_contacts`, `status`, `salutation`, `designation`, `gender`, `phone`, `mobile_no`, `company_name`, `image`, `google_contacts`, `google_contacts_id`, `pulled_from_google_contacts`, `is_primary_contact`, `is_billing_contact`, `department`, `unsubscribed`)\n\t\t\t\t\tVALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)'
      values = ['丰茂德', '1060778506@qq.com', '2026-03-02 16:38:15.181717', '2026-03-02 16:38:15.181717', '1060778506@qq.com', 0, 0, '丰茂德', None, '', '丰茂德', '1060778506@qq.com', '1060778506@qq.com', None, 0, 'Passive', None, None, None, '', '', None, '', None, None, 0, 0, 0, None, 0]
      as_dict = 0
      as_list = 0
      debug = False
      ignore_ddl = 0
      auto_commit = 0
      update = None
      explain = False
      run = True
      pluck = False
      as_iterator = False
      trace_id = None
frappe.exceptions.QueryDeadlockError: (1020, "Record has changed since last read in table 'tabContact'")



```










…n Insights is installed

## Environment

- Frappe version: v15.101.3 (latest)
- Insights version: 3.3.1
- MariaDB: 11.8 (official docker image)
- Deployment: Docker (custom image based on frappe/bench)
- Transaction isolation: REPEATABLE-READ (default)

## Steps to Reproduce

1. Fresh Docker deployment
2. Install Insights
3. Login for the first time
4. System automatically creates User → Contact
5. Background job `create_contact` runs
6. Error occurs

## Error

QueryDeadlockError: (1020, "Record has changed since last read in table 'tabContact'")

Traceback attached below.

## Observation

- If Insights is NOT installed → no error
- If database isolation level is changed to READ-COMMITTED → no error

## Suspected Cause

Insights hooks on Contact insert/update may be triggering additional DB reads/writes within the same transaction, which conflicts with MariaDB 11 default REPEATABLE READ isolation.

## Question

Should Insights defer its hooks using enqueue_after_commit=True or after_commit mechanism to avoid transaction conflicts under default MariaDB settings?

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
