### PR TITLE
fix(nginx): use X-Forwarded-Proto for backend requests behind reverse proxy

### DIFF
--- a/resources/core/nginx/nginx-template.conf
+++ b/resources/core/nginx/nginx-template.conf
@@ -69,7 +69,7 @@ server {
 	location @webserver {
 		proxy_http_version 1.1;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
 		proxy_set_header X-Frappe-Site-Name ${FRAPPE_SITE_NAME_HEADER};
 		proxy_set_header Host $host;
 		proxy_set_header X-Use-X-Accel-Redirect True;


### PR DESCRIPTION
Follow-up to #1817 .

Replaced `$scheme` with `$proxy_x_forwarded_proto` in `location @webserver` so the backend receives the correct protocol