### PR TITLE
fix(overrides): remove redis services from mariadb network in multi-b…

### DIFF
--- a/overrides/compose.multi-bench.yaml
+++ b/overrides/compose.multi-bench.yaml
@@ -37,12 +37,10 @@ services:
   redis-cache:
     networks:
       - bench-network
-      - mariadb-network
 
   redis-queue:
     networks:
       - bench-network
-      - mariadb-network
 
 networks:
   traefik-public:


### PR DESCRIPTION
…ench setup

In a multi-bench setup with a shared `mariadb-network`, services with the same name from different projects (e.g. `redis-cache`, `redis-queue`) can conflict. Docker DNS will randomly (round-robin) resolve these service names across different projects, so a bench can end up connecting to a different bench’s Redis. This resulted in problems like `frappe.boot.assets_json` returning asset hashes from the wrong bench.

This change removes `mariadb-network` from `redis-cache` and `redis-queue`, keeping them only on the internal `bench-network` so each bench always talks to its own Redis.
