### PR TITLE
fix: copy security_headers.conf before chown

### DIFF
--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -4,6 +4,7 @@ FROM python:${PYTHON_VERSION}-slim-${DEBIAN_BASE} AS base
 
 COPY resources/core/nginx/nginx-template.conf /templates/nginx/frappe.conf.template
 COPY resources/core/nginx/nginx-entrypoint.sh /usr/local/bin/nginx-entrypoint.sh
+COPY resources/core/nginx/security_headers.conf /etc/nginx/snippets/security_headers.conf
 
 ARG WKHTMLTOPDF_VERSION=0.12.6.1-3
 ARG WKHTMLTOPDF_DISTRO=bookworm
@@ -78,7 +79,6 @@ RUN useradd -ms /bin/bash frappe \
     && chmod 755 /usr/local/bin/nginx-entrypoint.sh \
     && chmod 644 /templates/nginx/frappe.conf.template
 
-COPY resources/core/nginx/security_headers.conf /etc/nginx/snippets/security_headers.conf
 
 FROM base AS builder
 


### PR DESCRIPTION
Closes #1847 

Before:
```
$ docker compose logs frontend
frontend-1  | PROXY_READ_TIMEOUT defaulting to 120
frontend-1  | 2026/03/25 01:56:20 [emerg] 8#8: open() "/etc/nginx/snippets/security_headers.conf" failed (13: Permission denied) in /etc/nginx/conf.d/frappe.conf:24
frontend-1  | PROXY_READ_TIMEOUT defaulting to 120
frontend-1  | 2026/03/25 01:56:21 [emerg] 9#9: open() "/etc/nginx/snippets/security_headers.conf" failed (13: Permission denied) in /etc/nginx/conf.d/frappe.conf:24
frontend-1  | PROXY_READ_TIMEOUT defaulting to 120
frontend-1  | 2026/03/25 01:56:23 [emerg] 8#8: open() "/etc/nginx/snippets/security_headers.conf" failed (13: Permission denied) in /etc/nginx/conf.d/frappe.conf:24
frontend-1  | PROXY_READ_TIMEOUT defaulting to 120
```

After:
```
$ docker compose logs frontend
frontend-1  | PROXY_READ_TIMEOUT defaulting to 120
```