### PR TITLE
fix: nginx redirects leak internal port

### DIFF
--- a/resources/core/nginx/nginx-template.conf
+++ b/resources/core/nginx/nginx-template.conf
@@ -15,7 +15,7 @@ map $http_x_forwarded_proto $proxy_x_forwarded_proto {
 server {
 	listen 8080;
 	server_name ${FRAPPE_SITE_NAME_HEADER};
-  port_in_redirect off;
+  absolute_redirect off;
 	root /home/frappe/frappe-bench/sites;
 
 	proxy_buffer_size 128k;


### PR DESCRIPTION
fixes #1851 

When accessing the Frappe app behind Traefik with HTTPS enforced, URLs ending with a trailing slash (e.g., `/app/`) are redirected to the internal container port (`:8080`).

Setting `port_in_redirect off;` fixes this.
This setting tells nginx never to append the listening port to redirects it generates.