### PR TITLE
Add pre-commit to devcontainer postCreateCommand

### DIFF
--- a/devcontainer-example/devcontainer.json
+++ b/devcontainer-example/devcontainer.json
@@ -44,6 +44,7 @@
   "service": "frappe",
   "workspaceFolder": "/workspace/development",
   "shutdownAction": "stopCompose",
+  "postCreateCommand": "uv tool install pre-commit",
   "mounts": [
     "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/frappe/.ssh,type=bind,consistency=cached"
   ]


### PR DESCRIPTION
**Add pre-commit to devcontainer postCreateCommand**

The Frappe devcontainer image includes `uv` as a dependency of `frappe-bench`. This PR uses it to automatically install `pre-commit` when the devcontainer is created, so developers have it available without any manual setup.

```json
"postCreateCommand": "uv tool install pre-commit"
```
