### PR TITLE
chore(vscode): exclude build artifacts and deps from file watcher

### DIFF
--- a/development/vscode-example/settings.json
+++ b/development/vscode-example/settings.json
@@ -1,3 +1,19 @@
 {
-  "python.defaultInterpreterPath": "${workspaceFolder}/frappe-bench/env/bin/python"
+  "python.defaultInterpreterPath": "${workspaceFolder}/frappe-bench/env/bin/python",
+  "files.watcherExclude": {
+    // --- Node modules ---
+    "**/node_modules/**": true,
+
+    // --- Frappe bench core dirs ---
+    "**/env/**": true,
+    "**/config/**": true,
+
+    // --- Build artifacts ---
+    "**/__pycache__/**": true,
+    "**/*.pyc": true
+  },
+  "files.exclude": {
+    "**/__pycache__": true,
+    "**/*.pyc": true
+  }
 }


### PR DESCRIPTION
### Reduce VS Code inotify watches for Frappe bench workspaces
Adds `files.watcherExclude` entries to prevent the "*Unable to watch for file changes (ENOSPC)*" error when developing in a Frappe bench workspace.

The excluded folders do not need to be watched IMO.

Also excludes `__pycache__/` and `*.pyc` from both the file watcher and the Explorer, as these are auto-generated Python bytecode files that are never useful to browse or track.