### PR TITLE
docs: add MAINTAINERS.md to document project maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,25 @@
+# Maintainers
+
+This project is actively maintained by the following people.
+
+Maintainers are responsible for:
+
+- Reviewing and merging pull requests
+- Managing releases
+- Triaging and responding to issues
+- Ensuring the overall health and direction of the project
+
+## Current Maintainers
+
+- [@revant](https://github.com/revant)
+- [@DanielRadlAMR](https://github.com/DanielRadlAMR)
+- [@Rocket-Quack](https://github.com/Rocket-Quack)
+
+## Emeritus Maintainers
+
+_(none)_
+
+## Becoming a Maintainer
+
+Contributors who consistently help review pull requests, participate in issue triage,
+and contribute to releases may be invited to become maintainers.


### PR DESCRIPTION
Introduce a `MAINTAINERS.md` file to clarify ownership, responsibilities, and points of contact. 
This helps contributors know who to reach out to for reviews and questions.