### PR TITLE
chore(vscode): show git folder

### DIFF
--- a/development/vscode-example/settings.json
+++ b/development/vscode-example/settings.json
@@ -14,6 +14,7 @@
   },
   "files.exclude": {
     "**/__pycache__": true,
-    "**/*.pyc": true
+    "**/*.pyc": true,
+    "**/.git": false
   }
 }


### PR DESCRIPTION
Addition to #1866 

Although the `.git` folder is hidden by default, it can be valuable to inspect during development.
This change makes it visible in the explorer for convenience.