### PR TITLE
fix: cap setuptools below v82 to retain pkg_resources

### DIFF
--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -137,7 +137,8 @@ RUN export APP_INSTALL_ARGS="" && \
     /home/frappe/frappe-bench && \
   cd /home/frappe/frappe-bench && \
   echo "{}" > sites/common_site_config.json && \
-  find apps -mindepth 1 -path "*/.git" | xargs rm -fr
+  find apps -mindepth 1 -path "*/.git" | xargs rm -fr && \
+  bench pip install "setuptools>=71.0.0,<82.0.0"
 
 FROM base AS backend
 

--- a/images/layered/Containerfile
+++ b/images/layered/Containerfile
@@ -28,7 +28,8 @@ RUN export APP_INSTALL_ARGS="" && \
     /home/frappe/frappe-bench && \
   cd /home/frappe/frappe-bench && \
   echo "{}" > sites/common_site_config.json && \
-  find apps -mindepth 1 -path "*/.git" | xargs rm -fr
+  find apps -mindepth 1 -path "*/.git" | xargs rm -fr && \
+  bench pip install "setuptools>=71.0.0,<82.0.0"
 
 FROM frappe/base:${FRAPPE_BRANCH} AS backend
 

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -123,7 +123,8 @@ RUN bench init \
   cd /home/frappe/frappe-bench && \
   bench get-app --branch=${ERPNEXT_BRANCH} --resolve-deps erpnext ${ERPNEXT_REPO} && \
   echo "{}" > sites/common_site_config.json && \
-  find apps -mindepth 1 -path "*/.git" | xargs rm -fr
+  find apps -mindepth 1 -path "*/.git" | xargs rm -fr && \
+  bench pip install "setuptools>=71.0.0,<82.0.0"
 
 FROM base AS erpnext
 


### PR DESCRIPTION
**Problem**
setuptools v82 removed `pkg_resources`. Frappe v15 depends on it via `google-api-python-client`, causing all requests to fail: **AttributeError: 'NotFoundPage' object has no attribute 'app_path'**

 **Fix**
Cap setuptools in the site venv after `bench init`, using the same constraint already merged in frappe/bench#1699.
