### PR TITLE
chore(compose): use MariaDB 11.8 and remove obsolete 10.6 workaround

### DIFF
--- a/devcontainer-example/docker-compose.yml
+++ b/devcontainer-example/docker-compose.yml
@@ -5,7 +5,6 @@ services:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
       - --skip-character-set-client-handshake
-      - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
     environment:
       MYSQL_ROOT_PASSWORD: 123
       MARIADB_AUTO_UPGRADE: 1

--- a/docs/01-getting-started/03-arm64.md
+++ b/docs/01-getting-started/03-arm64.md
@@ -100,7 +100,7 @@ services:
         bench new-site --mariadb-user-host-login-scope=% --admin-password=admin --db-root-password=admin --install-app erpnext --set-default frontend;
 
   db:
-    image: mariadb:10.6
+    image: mariadb:11.8
     platform: linux/amd64
     healthcheck:
       test: mysqladmin ping -h localhost --password=admin
@@ -113,7 +113,6 @@ services:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
       - --skip-character-set-client-handshake
-      - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
     environment:
       MYSQL_ROOT_PASSWORD: admin
     volumes:

--- a/overrides/compose.mariadb-shared.yaml
+++ b/overrides/compose.mariadb-shared.yaml
@@ -13,7 +13,6 @@ services:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
       - --skip-character-set-client-handshake
-      - --skip-innodb-read-only-compressed
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD:-changeit}
       MARIADB_AUTO_UPGRADE: 1

--- a/overrides/compose.mariadb.yaml
+++ b/overrides/compose.mariadb.yaml
@@ -20,7 +20,6 @@ services:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
       - --skip-character-set-client-handshake
-      - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD:-123}
       MARIADB_AUTO_UPGRADE: 1

--- a/pwd.yml
+++ b/pwd.yml
@@ -78,7 +78,7 @@ services:
         bench new-site --mariadb-user-host-login-scope='%' --admin-password=admin --db-root-username=root --db-root-password=admin --install-app erpnext --set-default frontend;
 
   db:
-    image: mariadb:10.6
+    image: mariadb:11.8
     networks:
       - frappe_network
     healthcheck:
@@ -92,7 +92,6 @@ services:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
       - --skip-character-set-client-handshake
-      - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
     environment:
       MYSQL_ROOT_PASSWORD: admin
       MARIADB_ROOT_PASSWORD: admin


### PR DESCRIPTION
## Summary

This updates `pwd.yml` and the ARM64 example to use MariaDB 11.8 and removes
the legacy `--skip-innodb-read-only-compressed` workaround that was originally
introduced for MariaDB 10.6.

It also removes the same obsolete workaround from the MariaDB override files
and the devcontainer example, making MariaDB usage in the repository more
consistent.

Background information on the later reverted change in MariaDB 10.6 that made the workaround necessary:
[MariaDBDocs](https://mariadb.com/docs/server/server-usage/storage-engines/innodb/innodb-row-formats/innodb-compressed-row-format#read-only)

## Testing

- Ran `pre-commit run --all-files`
  - all hooks passed except `pyupgrade`, which failed locally with Python 3.14
- Ran `pytest` with:
  - `FRAPPE_VERSION=v16.0.0`
  - `ERPNEXT_VERSION=v16.0.0`
- `pytest` executed successfully, with one unrelated failing test:
  - `tests/test_frappe_docker.py::test_files_html_security_headers`
- Validated compose files with `docker compose config`

## Related Issues

Related to #1810
Closes #1874