### PR TITLE
chore: bump redis from 6.2 to 8.6-alpine

### DIFF
--- a/overrides/compose.redis.yaml
+++ b/overrides/compose.redis.yaml
@@ -8,11 +8,11 @@ services:
       - redis-queue
 
   redis-cache:
-    image: redis:6.2-alpine
+    image: redis:8.6-alpine
     restart: unless-stopped
 
   redis-queue:
-    image: redis:6.2-alpine
+    image: redis:8.6-alpine
     restart: unless-stopped
     volumes:
       - redis-queue-data:/data


### PR DESCRIPTION
## Problem

The `redis-cache` & `redis-queue` service in the compose file `compose.redis.yaml` was pinned to `redis:6.2-alpine`. 

Redis 6.2 was released on February 22, 2021 and its active support ended over 3 years ago on April 27, 2022. While it still receives security updates, it is no longer actively maintained and running on an unsupported release cycle. Upgrading to a fully supported version reduces long-term security risk and ensures compatibility with future improvements.

## Solution

Bump `redis` from `6.2-alpine` to `8.6-alpine`, which is the current stable release as of February 11, 2026 with active support and no scheduled EOL date.

## Redis Release Timeline

| Version | Release Date | Active Support | EOL | Latest Version | LTS | Status |
|---------|-------------|---------------|-----|---------------|-----|--------|
| **8.6** | **Feb 11, 2026** | **Yes** | **-** | **8.6.2** | **No** | **✅ Active** |
| 8.4 | Nov 18, 2025 | Feb 11, 2026 | - | 8.4.2 | No | 🔒 Security |
| 8.2 | Aug 4, 2025 | Nov 18, 2025 | - | 8.2.5 | No | 🔒 Security |
| 8.0 | May 2, 2025 | Aug 4, 2025 | Feb 11, 2026 | 8.0.6 | No | ⚠️ EOL |
| 7.4 | Jul 29, 2024 | May 2, 2025 | - | 7.4.8 | No | 🔒 Security |
| 7.2 | Aug 15, 2023 | Jul 29, 2024 | - | 7.2.13 | No | 🔒 Security |
| 7.0 | Apr 27, 2022 | Aug 15, 2023 | Jul 29, 2024 | 7.0.15 | No | ⚠️ EOL |
| **6.2** | **Feb 22, 2021** | **Apr 27, 2022** | **-** | **6.2.21** | **No** | **🔒 Security** |
| 6.0 | Apr 30, 2020 | Feb 22, 2021 | May 31, 2022 | 6.0.20 | No | ⚠️ EOL |
| 5.0 | Oct 17, 2018 | Apr 30, 2020 | Apr 27, 2022 | 5.0.14 | No | ⚠️ EOL |

## References

- https://eol.wiki/redis/