### PR TITLE
Use `mariadb-admin` for health check

### DIFF
--- a/pwd.yml
+++ b/pwd.yml
@@ -82,9 +82,11 @@ services:
     networks:
       - frappe_network
     healthcheck:
-      test: mariadb-admin ping -h localhost --password=admin
-      interval: 1s
-      retries: 20
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 5s
+      interval: 5s
+      timeout: 5s
+      retries: 5
     deploy:
       restart_policy:
         condition: on-failure

--- a/pwd.yml
+++ b/pwd.yml
@@ -82,7 +82,7 @@ services:
     networks:
       - frappe_network
     healthcheck:
-      test: mysqladmin ping -h localhost --password=admin
+      test: mariadb-admin ping -h localhost --password=admin
       interval: 1s
       retries: 20
     deploy:


### PR DESCRIPTION
mysql_upgrade is not existing anymore in the new 11.x images

