### PR TITLE
fix(workflows): allow stable env update push

### DIFF
--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -7,6 +7,6 @@ jobs:
   delegate:
     uses: ./.github/workflows/core-build-stable.yml
     permissions:
-      contents: read
+      contents: write
       packages: write
     secrets: inherit

--- a/.github/workflows/core-build-stable.yml
+++ b/.github/workflows/core-build-stable.yml
@@ -89,6 +89,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'frappe/frappe_docker' && github.event_name != 'pull_request' }}
     needs: v16_publish
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Fixes the stable build workflow self-update job after the workflow split needed write permission to change main branch in the repo
