### PR TITLE
feat: configure gunicorn with env variables

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -46,6 +46,10 @@ services:
   backend:
     <<: *backend_defaults
     platform: linux/amd64
+    environment:
+      GUNICORN_THREADS: ${GUNICORN_THREADS:-4}
+      GUNICORN_WORKERS: ${GUNICORN_WORKERS:-2}
+      GUNICORN_TIMEOUT: ${GUNICORN_TIMEOUT:-120}
 
   frontend:
     <<: *customizable_image

--- a/docs/02-setup/04-env-variables.md
+++ b/docs/02-setup/04-env-variables.md
@@ -122,6 +122,16 @@ If your site is named `example.com` and you access it via that domain, no need t
 
 ---
 
+## Backend (Gunicorn) Configuration
+
+| Variable           | Purpose                                                        | Default | When to Set / Allowed Values                                                     |
+| :----------------- | :------------------------------------------------------------- | :------ | :------------------------------------------------------------------------------- |
+| `GUNICORN_WORKERS` | Number of worker processes handling web requests               | `2`     | Scale up for multi-core CPUs. Formula: `(2 x Cores) + 1`                         |
+| `GUNICORN_THREADS` | Number of concurrent threads per worker process                | `4`     | Increase to handle more simultaneous I/O-bound requests without high memory cost |
+| `GUNICORN_TIMEOUT` | Max time a worker can spend on a single request before restart | `120`   | Increase if long-running reports or data imports time out                        |
+
+---
+
 ## Frontend Nginx Configuration (inside the frontend container)
 
 | Variable               | Purpose                            | Default        | Allowed Values                               |

--- a/example.env
+++ b/example.env
@@ -15,6 +15,17 @@ DB_PORT=
 REDIS_CACHE=
 REDIS_QUEUE=
 
+
+# The number of threads per Gunicorn worker process for handling concurrent requests.
+GUNICORN_THREADS=4
+
+# The number of worker processes for handling requests.
+# A typical formula is (2 x number of CPU cores) + 1.
+GUNICORN_WORKERS=2
+
+# Workers exceeding this timeout (in seconds) will be killed and restarted.
+GUNICORN_TIMEOUT=120
+
 # Only with HTTPS override
 LETSENCRYPT_EMAIL=mail@example.com
 

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -165,18 +165,10 @@ USER root
 COPY resources/core/main-entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod 755 /usr/local/bin/entrypoint.sh
 
+COPY resources/core/start.sh /usr/local/bin/start.sh
+RUN chmod 755 /usr/local/bin/start.sh
+
 USER frappe
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
-CMD [ \
-  "/home/frappe/frappe-bench/env/bin/gunicorn", \
-  "--chdir=/home/frappe/frappe-bench/sites", \
-  "--bind=0.0.0.0:8000", \
-  "--threads=4", \
-  "--workers=2", \
-  "--worker-class=gthread", \
-  "--worker-tmp-dir=/dev/shm", \
-  "--timeout=120", \
-  "--preload", \
-  "frappe.app:application" \
-]
+CMD ["start.sh"]

--- a/images/layered/Containerfile
+++ b/images/layered/Containerfile
@@ -49,18 +49,10 @@ USER root
 COPY resources/core/main-entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod 755 /usr/local/bin/entrypoint.sh
 
+COPY resources/core/start.sh /usr/local/bin/start.sh
+RUN chmod 755 /usr/local/bin/start.sh
+
 USER frappe
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
-CMD [ \
-  "/home/frappe/frappe-bench/env/bin/gunicorn", \
-  "--chdir=/home/frappe/frappe-bench/sites", \
-  "--bind=0.0.0.0:8000", \
-  "--threads=4", \
-  "--workers=2", \
-  "--worker-class=gthread", \
-  "--worker-tmp-dir=/dev/shm", \
-  "--timeout=120", \
-  "--preload", \
-  "frappe.app:application" \
-]
+CMD ["start.sh"]

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -156,18 +156,10 @@ USER root
 COPY resources/core/main-entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod 755 /usr/local/bin/entrypoint.sh
 
+COPY resources/core/start.sh /usr/local/bin/start.sh
+RUN chmod 755 /usr/local/bin/start.sh
+
 USER frappe
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
-CMD [ \
-  "/home/frappe/frappe-bench/env/bin/gunicorn", \
-  "--chdir=/home/frappe/frappe-bench/sites", \
-  "--bind=0.0.0.0:8000", \
-  "--threads=4", \
-  "--workers=2", \
-  "--worker-class=gthread", \
-  "--worker-tmp-dir=/dev/shm", \
-  "--timeout=120", \
-  "--preload", \
-  "frappe.app:application" \
-]
+CMD ["start.sh"]

--- a/resources/core/start.sh
+++ b/resources/core/start.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+#Gunicorn defaults
+GUNICORN_THREADS=${GUNICORN_THREADS:-4}
+GUNICORN_WORKERS=${GUNICORN_WORKERS:-2}
+GUNICORN_TIMEOUT=${GUNICORN_TIMEOUT:-120}
+
+echo "Booting Gunicorn with $GUNICORN_WORKERS workers and $GUNICORN_THREADS threads..."
+
+exec /home/frappe/frappe-bench/env/bin/gunicorn \
+  --chdir=/home/frappe/frappe-bench/sites \
+  --bind=0.0.0.0:8000 \
+  --threads="$GUNICORN_THREADS" \
+  --workers="$GUNICORN_WORKERS" \
+  --worker-class=gthread \
+  --worker-tmp-dir=/dev/shm \
+  --timeout="$GUNICORN_TIMEOUT" \
+  --preload \
+  frappe.app:application


### PR DESCRIPTION
This PR also adds supports for customizing gunicorn values. It is reasonable to be able to configure the number of gunicorn workers and thread that you have, and this PR supports that by adding environment variables to do so.

For instance, you can have a bench with 10+ sites, and 2 gunicorn workers is not enough, there's no reason to have to manually modify the hardcoded dockerfile to increment the workers, you should just be able to configure that by environment variables.