### PR TITLE
fix: embed entrypoint for layered image

### DIFF
--- a/images/layered/Containerfile
+++ b/images/layered/Containerfile
@@ -46,8 +46,21 @@ VOLUME [ \
 
 USER root
 # This entrypoint script link build assets of the image to the mounted sites volume at container initialization
-COPY resources/core/main-entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+RUN cat <<'EOF' > /usr/local/bin/entrypoint.sh \
+ && chmod +x /usr/local/bin/entrypoint.sh
+#!/bin/bash
+set -e
+
+ASSETS_PATH="/home/frappe/frappe-bench/sites/assets"
+BAKED_PATH="/home/frappe/frappe-bench/assets"
+
+echo "Linking fresh assets to volume..."
+rm -rf "$ASSETS_PATH"
+mkdir -p "$(dirname "$ASSETS_PATH")"
+ln -s "$BAKED_PATH" "$ASSETS_PATH"
+
+exec "$@"
+EOF
 
 USER frappe
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
the `images\layered` uses an existing frappe build as base image. With that, it doesn't use the context of `frappe_docker` for the build context, this cause the local COPY instructions to fail. 

This PR replaces the copy of the entrypoint to be embedded into the Dockerfile.