### PR TITLE
Add pycups as optional install feature

### DIFF
--- a/docs/02-setup/02-build-setup.md
+++ b/docs/02-setup/02-build-setup.md
@@ -96,6 +96,7 @@ See [Automated Builds and Deployment](../03-production/06-automated-builds-and-d
 | PYTHON_VERSION       | Python version for the base image                                                                                                 |
 | NODE_VERSION         | Node.js version                                                                                                                   |
 | WKHTMLTOPDF_VERSION  | wkhtmltopdf version                                                                                                               |
+| INSTALL_PYCUPS       | Set true to install pycups and its dependencies; see <https://docs.frappe.io/erpnext/print-settings>                              |
 | **bench only**       |                                                                                                                                   |
 | DEBIAN_BASE          | Debian base version for the bench image, defaults to `bookworm`                                                                   |
 | WKHTMLTOPDF_DISTRO   | use the specified distro for debian package. Default is `bookworm`                                                                |

--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -81,7 +81,7 @@ RUN apt-get update \
         chromium-headless-shell; \
     fi \
     # Install cups 
-    && if [ "${INSTALL_PYCUPS}" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client fi \
+    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client fi \
     && rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
@@ -155,7 +155,7 @@ RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | 
     && echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion' >> ~/.bashrc
 
 # Install pycups
-RUN if [ "${INSTALL_PYCUPS}" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups fi \
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups fi \
 
 EXPOSE 8000-8005 9000-9005 6787
 

--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -124,6 +124,10 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git .pyenv \
     && echo 'eval "$(pyenv init --path)"' >>~/.profile \
     && echo 'eval "$(pyenv init -)"' >>~/.bashrc
 
+
+    # Install pycups
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then pip install --no-cache-dir pycups; fi \
+
 # Clone and install bench in the local user home directory
 # For development, bench source is located in ~/.bench
 ENV PATH=/home/frappe/.local/bin:$PATH

--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -81,7 +81,7 @@ RUN apt-get update \
         chromium-headless-shell; \
     fi \
     # Install cups 
-    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client fi \
+    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client; fi \
     && rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \

--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -5,6 +5,7 @@ LABEL author=frappé
 ARG GIT_REPO=https://github.com/frappe/bench.git
 ARG GIT_BRANCH=v5.x
 ARG INSTALL_CHROMIUM=true
+ARG INSTALL_PYCUPS=false
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
@@ -79,6 +80,8 @@ RUN apt-get update \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         chromium-headless-shell; \
     fi \
+    # Install cups 
+    && if [ "${INSTALL_PYCUPS}" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client fi \
     && rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
@@ -151,6 +154,8 @@ RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | 
     && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm' >> ~/.bashrc \
     && echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion' >> ~/.bashrc
 
+# Install pycups
+RUN if [ "${INSTALL_PYCUPS}" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups fi \
 
 EXPOSE 8000-8005 9000-9005 6787
 

--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -81,7 +81,7 @@ RUN apt-get update \
         chromium-headless-shell; \
     fi \
     # Install cups 
-    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client; fi \
+    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install -y libcups2-dev; fi \
     && rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \

--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -155,7 +155,7 @@ RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | 
     && echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion' >> ~/.bashrc
 
 # Install pycups
-RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi
 
 EXPOSE 8000-8005 9000-9005 6787
 

--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -155,7 +155,7 @@ RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | 
     && echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion' >> ~/.bashrc
 
 # Install pycups
-RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups fi \
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi \
 
 EXPOSE 8000-8005 9000-9005 6787
 

--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -5,6 +5,7 @@ LABEL author=frappé
 ARG GIT_REPO=https://github.com/frappe/bench.git
 ARG GIT_BRANCH=v5.x
 ARG INSTALL_CHROMIUM=true
+ARG INSTALL_PYCUPS=false
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
@@ -79,6 +80,8 @@ RUN apt-get update \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         chromium-headless-shell; \
     fi \
+    # Install cups 
+    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client; fi \
     && rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
@@ -151,6 +154,8 @@ RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | 
     && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm' >> ~/.bashrc \
     && echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion' >> ~/.bashrc
 
+# Install pycups
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi
 
 EXPOSE 8000-8005 9000-9005 6787
 

--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -155,7 +155,7 @@ RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | 
     && echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion' >> ~/.bashrc
 
 # Install pycups
-RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi \
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi
 
 EXPOSE 8000-8005 9000-9005 6787
 

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -123,7 +123,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pycups
-RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi \
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi
 
 USER frappe
 

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -64,7 +64,7 @@ RUN useradd -ms /bin/bash frappe \
     && apt-get install -y ./$downloaded_file \
     && rm $downloaded_file \
     # Install cups 
-    && if [ "${INSTALL_PYCUPS}" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client fi \
+    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client fi \
     # Chromium
     && if [ "$INSTALL_CHROMIUM" != "false" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
@@ -123,7 +123,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pycups
-RUN if [ "${INSTALL_PYCUPS}" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups fi \
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups fi \
 
 USER frappe
 

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -76,7 +76,7 @@ RUN useradd -ms /bin/bash frappe \
     && mkdir -p /etc/nginx/snippets \
     && pip3 install frappe-bench \
     # Install pycups
-    && if [ "$INSTALL_PYCUPS" != "false" ]; then /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi \
+    && if [ "$INSTALL_PYCUPS" != "false" ]; then pip install --no-cache-dir pycups; fi \
     # Fixes for non-root nginx and logs to stdout
     && sed -i '/user www-data/d' /etc/nginx/nginx.conf \
     && ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log \

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -64,7 +64,7 @@ RUN useradd -ms /bin/bash frappe \
     && apt-get install -y ./$downloaded_file \
     && rm $downloaded_file \
     # Install cups 
-    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client; fi \
+    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install -y libcups2-dev; fi \
     # Chromium
     && if [ "$INSTALL_CHROMIUM" != "false" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -123,7 +123,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pycups
-RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi
 
 USER frappe
 

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -64,7 +64,7 @@ RUN useradd -ms /bin/bash frappe \
     && apt-get install -y ./$downloaded_file \
     && rm $downloaded_file \
     # Install cups 
-    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client fi \
+    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client; fi \
     # Chromium
     && if [ "$INSTALL_CHROMIUM" != "false" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -122,6 +122,9 @@ RUN apt-get update \
     libbz2-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Install pycups
+RUN if [ "${INSTALL_PYCUPS}" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups fi \
+
 USER frappe
 
 ARG FRAPPE_BRANCH=version-16

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -75,6 +75,8 @@ RUN useradd -ms /bin/bash frappe \
     && rm -fr /etc/nginx/sites-enabled/default \
     && mkdir -p /etc/nginx/snippets \
     && pip3 install frappe-bench \
+    # Install pycups
+    && if [ "$INSTALL_PYCUPS" != "false" ]; then /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi \
     # Fixes for non-root nginx and logs to stdout
     && sed -i '/user www-data/d' /etc/nginx/nginx.conf \
     && ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log \
@@ -122,8 +124,7 @@ RUN apt-get update \
     libbz2-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install pycups
-RUN if [ "$INSTALL_PYCUPS" != "false" ]; then /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi
+
 
 USER frappe
 

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -64,7 +64,7 @@ RUN useradd -ms /bin/bash frappe \
     && apt-get install -y ./$downloaded_file \
     && rm $downloaded_file \
     # Install cups 
-    && if [ "${INSTALL_PYCUPS}" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client fi \
+    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client; fi \
     # Chromium
     && if [ "$INSTALL_CHROMIUM" != "false" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
@@ -121,6 +121,9 @@ RUN apt-get update \
     build-essential \
     libbz2-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Install pycups
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi
 
 USER frappe
 

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -123,7 +123,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pycups
-RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups fi \
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi \
 
 USER frappe
 

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -11,6 +11,7 @@ ARG WKHTMLTOPDF_DISTRO=bookworm
 ARG NODE_VERSION=24.13.0
 ENV NVM_DIR=/home/frappe/.nvm
 ENV PATH=${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}
+ARG INSTALL_PYCUPS=false
 
 RUN useradd -ms /bin/bash frappe \
     && apt-get update \
@@ -62,6 +63,8 @@ RUN useradd -ms /bin/bash frappe \
     && curl -sLO https://github.com/wkhtmltopdf/packaging/releases/download/$WKHTMLTOPDF_VERSION/$downloaded_file \
     && apt-get install -y ./$downloaded_file \
     && rm $downloaded_file \
+    # Install cups 
+    && if [ "${INSTALL_PYCUPS}" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client fi \
     # Clean up
     && rm -rf /var/lib/apt/lists/* \
     && rm -fr /etc/nginx/sites-enabled/default \

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -115,7 +115,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pycups
-RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi
 
 USER frappe
 

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -115,7 +115,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pycups
-RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups fi \
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi \
 
 USER frappe
 

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -60,7 +60,7 @@ RUN useradd -ms /bin/bash frappe \
     && apt-get install -y ./$downloaded_file \
     && rm $downloaded_file \
     # Install cups 
-    && if [ "${INSTALL_PYCUPS}" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client fi \
+    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client fi \
     # Chromium
     && if [ "$INSTALL_CHROMIUM" != "false" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
@@ -115,7 +115,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pycups
-RUN if [ "${INSTALL_PYCUPS}" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups fi \
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups fi \
 
 USER frappe
 

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -60,7 +60,7 @@ RUN useradd -ms /bin/bash frappe \
     && apt-get install -y ./$downloaded_file \
     && rm $downloaded_file \
     # Install cups 
-    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client fi \
+    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client; fi \
     # Chromium
     && if [ "$INSTALL_CHROMIUM" != "false" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -60,7 +60,7 @@ RUN useradd -ms /bin/bash frappe \
     && apt-get install -y ./$downloaded_file \
     && rm $downloaded_file \
     # Install cups 
-    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client; fi \
+    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install -y libcups2-dev; fi \
     # Chromium
     && if [ "$INSTALL_CHROMIUM" != "false" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -71,6 +71,8 @@ RUN useradd -ms /bin/bash frappe \
     && rm -fr /etc/nginx/sites-enabled/default \
     && mkdir -p /etc/nginx/snippets \
     && pip3 install frappe-bench \
+    # Install pycups
+    && if [ "$INSTALL_PYCUPS" != "false" ]; then /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi \
     # Fixes for non-root nginx and logs to stdout
     && sed -i '/user www-data/d' /etc/nginx/nginx.conf \
     && ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log \
@@ -114,8 +116,7 @@ RUN apt-get update \
     libbz2-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install pycups
-RUN if [ "$INSTALL_PYCUPS" != "false" ]; then /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi
+
 
 USER frappe
 

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -7,6 +7,7 @@ ARG WKHTMLTOPDF_DISTRO=bookworm
 ARG NODE_VERSION=24.13.0
 ENV NVM_DIR=/home/frappe/.nvm
 ENV PATH=${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}
+ARG INSTALL_PYCUPS=false
 
 RUN useradd -ms /bin/bash frappe \
     && apt-get update \
@@ -58,6 +59,8 @@ RUN useradd -ms /bin/bash frappe \
     && curl -sLO https://github.com/wkhtmltopdf/packaging/releases/download/$WKHTMLTOPDF_VERSION/$downloaded_file \
     && apt-get install -y ./$downloaded_file \
     && rm $downloaded_file \
+    # Install cups 
+    && if [ "${INSTALL_PYCUPS}" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client fi \
     # Clean up
     && rm -rf /var/lib/apt/lists/* \
     && rm -fr /etc/nginx/sites-enabled/default \

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -114,6 +114,9 @@ RUN apt-get update \
     libbz2-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Install pycups
+RUN if [ "${INSTALL_PYCUPS}" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups fi \
+
 USER frappe
 
 FROM build AS builder

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -60,7 +60,7 @@ RUN useradd -ms /bin/bash frappe \
     && apt-get install -y ./$downloaded_file \
     && rm $downloaded_file \
     # Install cups 
-    && if [ "${INSTALL_PYCUPS}" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client fi \
+    && if [ "$INSTALL_PYCUPS" != "false" ]; then apt-get install --no-install-recommends -y libcups2-dev cups-client; fi \
     # Chromium
     && if [ "$INSTALL_CHROMIUM" != "false" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
@@ -113,6 +113,9 @@ RUN apt-get update \
     build-essential \
     libbz2-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Install pycups
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi
 
 USER frappe
 

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -115,7 +115,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pycups
-RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi \
+RUN if [ "$INSTALL_PYCUPS" != "false" ]; then RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups; fi
 
 USER frappe
 


### PR DESCRIPTION
This PR adds option to install pycups and dependencies to custom docker images, using INSTALL_PYCUPS build argument. 
Resolves #1895. 

Todo:
'layered' image changes
`RUN /home/frappe/frappe-bench/env/bin/pip install --no-cache-dir pycups` command