### PR TITLE
feat(images): toggle chromium installation

### DIFF
--- a/docs/02-setup/02-build-setup.md
+++ b/docs/02-setup/02-build-setup.md
@@ -96,6 +96,7 @@ See [Automated Builds and Deployment](../03-production/06-automated-builds-and-d
 | PYTHON_VERSION       | Python version for the base image                                                                                                 |
 | NODE_VERSION         | Node.js version                                                                                                                   |
 | WKHTMLTOPDF_VERSION  | wkhtmltopdf version                                                                                                               |
+| INSTALL_CHROMIUM     | Configure chromium installation, defaults to `true` - needed for Frappe Workbench version >15                                     |
 | **bench only**       |                                                                                                                                   |
 | DEBIAN_BASE          | Debian base version for the bench image, defaults to `bookworm`                                                                   |
 | WKHTMLTOPDF_DISTRO   | use the specified distro for debian package. Default is `bookworm`                                                                |

--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -75,7 +75,7 @@ RUN apt-get update \
     # For MIME type detection
     media-types \
     # Chromium
-    && if [ "$INSTALL_CHROMIUM" = "true" ]; then \
+    && if [ "$INSTALL_CHROMIUM" != "false" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         chromium-headless-shell; \
     fi \

--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -4,6 +4,7 @@ LABEL author=frappé
 
 ARG GIT_REPO=https://github.com/frappe/bench.git
 ARG GIT_BRANCH=v5.x
+ARG INSTALL_CHROMIUM=true
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
@@ -23,8 +24,6 @@ RUN apt-get update \
     libharfbuzz0b \
     libpangoft2-1.0-0 \
     libpangocairo-1.0-0 \
-    #Chromium
-    chromium-headless-shell \
     # to work inside the container
     locales \
     build-essential \
@@ -75,6 +74,11 @@ RUN apt-get update \
     file \
     # For MIME type detection
     media-types \
+    # Chromium
+    && if [ "$INSTALL_CHROMIUM" = "true" ]; then \
+        DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        chromium-headless-shell; \
+    fi \
     && rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -63,7 +63,7 @@ RUN useradd -ms /bin/bash frappe \
     && apt-get install -y ./$downloaded_file \
     && rm $downloaded_file \
     # Chromium
-    && if [ "$INSTALL_CHROMIUM" = "true" ]; then \
+    && if [ "$INSTALL_CHROMIUM" != "false" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         chromium-headless-shell; \
     fi \

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -8,6 +8,8 @@ COPY resources/core/nginx/security_headers.conf /etc/nginx/snippets/security_hea
 
 ARG WKHTMLTOPDF_VERSION=0.12.6.1-3
 ARG WKHTMLTOPDF_DISTRO=bookworm
+ARG INSTALL_CHROMIUM=true
+
 ARG NODE_VERSION=24.13.0
 ENV NVM_DIR=/home/frappe/.nvm
 ENV PATH=${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}
@@ -26,8 +28,6 @@ RUN useradd -ms /bin/bash frappe \
     libharfbuzz0b \
     libpangoft2-1.0-0 \
     libpangocairo-1.0-0 \
-    #Chromium
-    chromium-headless-shell \
     # For backups
     restic \
     gpg \
@@ -62,6 +62,11 @@ RUN useradd -ms /bin/bash frappe \
     && curl -sLO https://github.com/wkhtmltopdf/packaging/releases/download/$WKHTMLTOPDF_VERSION/$downloaded_file \
     && apt-get install -y ./$downloaded_file \
     && rm $downloaded_file \
+    # Chromium
+    && if [ "$INSTALL_CHROMIUM" = "true" ]; then \
+        DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        chromium-headless-shell; \
+    fi \
     # Clean up
     && rm -rf /var/lib/apt/lists/* \
     && rm -fr /etc/nginx/sites-enabled/default \

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -4,6 +4,8 @@ FROM python:${PYTHON_VERSION}-slim-${DEBIAN_BASE} AS base
 
 ARG WKHTMLTOPDF_VERSION=0.12.6.1-3
 ARG WKHTMLTOPDF_DISTRO=bookworm
+ARG INSTALL_CHROMIUM=true
+
 ARG NODE_VERSION=24.13.0
 ENV NVM_DIR=/home/frappe/.nvm
 ENV PATH=${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}
@@ -22,8 +24,6 @@ RUN useradd -ms /bin/bash frappe \
     libharfbuzz0b \
     libpangoft2-1.0-0 \
     libpangocairo-1.0-0 \
-    #Chromium
-    chromium-headless-shell \
     # For backups
     restic \
     gpg \
@@ -58,6 +58,11 @@ RUN useradd -ms /bin/bash frappe \
     && curl -sLO https://github.com/wkhtmltopdf/packaging/releases/download/$WKHTMLTOPDF_VERSION/$downloaded_file \
     && apt-get install -y ./$downloaded_file \
     && rm $downloaded_file \
+    # Chromium
+    && if [ "$INSTALL_CHROMIUM" = "true" ]; then \
+        DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        chromium-headless-shell; \
+    fi \
     # Clean up
     && rm -rf /var/lib/apt/lists/* \
     && rm -fr /etc/nginx/sites-enabled/default \

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -59,7 +59,7 @@ RUN useradd -ms /bin/bash frappe \
     && apt-get install -y ./$downloaded_file \
     && rm $downloaded_file \
     # Chromium
-    && if [ "$INSTALL_CHROMIUM" = "true" ]; then \
+    && if [ "$INSTALL_CHROMIUM" != "false" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         chromium-headless-shell; \
     fi \


### PR DESCRIPTION
## Summary

Adds an optional `INSTALL_CHROMIUM` build argument to the bench, custom and production images.

Chromium installation remains enabled by default, but can now be disabled to reduce image size for setups that do not require Chromium-based PDF generation, i.e. Frappe Workbench 15 with ERPNext 15.

Closes #1859.

## Testing

* `docker build -f images/bench/Dockerfile images/bench`
* `docker build -f images/bench/Dockerfile --build-arg INSTALL_CHROMIUM=false images/bench`
* `docker build -f images/custom/Containerfile .`
* `docker build -f images/custom/Containerfile --build-arg INSTALL_CHROMIUM=false .`
* `docker build -f images/production/Containerfile .`
* `docker build -f images/production/Containerfile --build-arg INSTALL_CHROMIUM=false .`
* Verified `chromium-headless-shell` presence/absence accordingly
* `docker compose config`
* `pre-commit run --all-files`

  * `pyupgrade` failed locally on Python 3.14 with:
    `TypeError: cannot use a bytes pattern on a string-like object`
  * all other hooks passed

