### PR TITLE
fix(compose): configure chromium binary path for print designer

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -25,6 +25,7 @@ services:
       - -c
     # add redis_socketio for backward compatibility
     command:
+      # chromium_binary_path: Temporary compatibility fix for Print Designer until https://github.com/frappe/print_designer/pull/523
       - >
         ls -1 apps > sites/apps.txt;
         bench set-config -g db_host $$DB_HOST;
@@ -34,6 +35,7 @@ services:
         bench set-config -g redis_socketio "redis://$$REDIS_QUEUE";
         bench set-config -gp socketio_port $$SOCKETIO_PORT;
         bench set-config -g chromium_path /usr/bin/chromium-headless-shell;
+        bench set-config -g chromium_binary_path /usr/bin/chromium-headless-shell;
     environment:
       DB_HOST: ${DB_HOST:-}
       DB_PORT: ${DB_PORT:-}


### PR DESCRIPTION
## Summary

`compose.yaml` already configures `chromium_path` for the bundled `chromium-headless-shell`, but Print Designer currently expects `chromium_binary_path` instead.

This adds a temporary compatibility workaround by setting both configuration keys to the same Chromium binary path.

A short inline note was added to reference the corresponding upstream Print Designer PR.

Fixes #1821.
Needed until https://github.com/frappe/print_designer/pull/523 got merged.

## Testing

* Ran `pre-commit run --all-files`
* Ran `docker compose -f compose.yaml config`
* Verified that both Chromium config values are written correctly:

```bash
ERPNEXT_VERSION=version-16 docker compose -f compose.yaml run --rm backend \ 
grep chromium sites/common_site_config.json
```
