### PR TITLE
fix: use MariaDB 10.6 to prevent new-site deadlock in pwd.yml

### DIFF
--- a/pwd.yml
+++ b/pwd.yml
@@ -78,7 +78,7 @@ services:
         bench new-site --mariadb-user-host-login-scope='%' --admin-password=admin --db-root-username=root --db-root-password=admin --install-app erpnext --set-default frontend;
 
   db:
-    image: mariadb:11.8
+    image: mariadb:10.6
     networks:
       - frappe_network
     healthcheck:


### PR DESCRIPTION
Fixes #1907