### PR TITLE
feat(actions):add exept issue label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,3 +16,4 @@ jobs:
           stale-pr-message: This PR has been automatically marked as stale. You have a week to explain why you believe this is an error.
           stale-issue-label: no-issue-activity
           stale-pr-label: no-pr-activity
+          exempt-issue-labels: keep-open


### PR DESCRIPTION
Currently there is no way to exclude issues or PRs from the stale workflow.

This PR exempts issues with the `keep-open` label.
