### PR TITLE
fix(pwd.yml): add configurator dependency to backend services; check for existing site before creation

### DIFF
--- a/pwd.yml
+++ b/pwd.yml
@@ -14,6 +14,9 @@ services:
       DB_PORT: "3306"
       MYSQL_ROOT_PASSWORD: admin
       MARIADB_ROOT_PASSWORD: admin
+    depends_on:
+      configurator:
+        condition: service_completed_successfully
 
   configurator:
     image: frappe/erpnext:v16.29.0
@@ -75,7 +78,7 @@ services:
           fi
         done;
         echo "sites/common_site_config.json found";
-        bench new-site --mariadb-user-host-login-scope='%' --admin-password=admin --db-root-username=root --db-root-password=admin --install-app erpnext --set-default frontend;
+        bench new-site --mariadb-user-host-login-scope='%' --admin-password=admin --db-root-username=root --db-root-password=admin --install-app erpnext --set-default frontend --force;
 
   db:
     image: mariadb:11.8
@@ -106,6 +109,7 @@ services:
       - frappe_network
     depends_on:
       - websocket
+      - backend
     deploy:
       restart_policy:
         condition: on-failure
@@ -144,6 +148,9 @@ services:
     environment:
       FRAPPE_REDIS_CACHE: redis://redis-cache:6379
       FRAPPE_REDIS_QUEUE: redis://redis-queue:6379
+    depends_on:
+      configurator:
+        condition: service_completed_successfully
 
   queue-short:
     image: frappe/erpnext:v16.29.0
@@ -163,6 +170,9 @@ services:
     environment:
       FRAPPE_REDIS_CACHE: redis://redis-cache:6379
       FRAPPE_REDIS_QUEUE: redis://redis-queue:6379
+    depends_on:
+      configurator:
+        condition: service_completed_successfully
 
   redis-queue:
     image: redis:6.2-alpine
@@ -195,6 +205,9 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs
+    depends_on:
+      configurator:
+        condition: service_completed_successfully
 
   websocket:
     image: frappe/erpnext:v16.29.0
@@ -212,6 +225,9 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs
+    depends_on:
+      configurator:
+        condition: service_completed_successfully
 
 volumes:
   db-data:

--- a/pwd.yml
+++ b/pwd.yml
@@ -78,7 +78,11 @@ services:
           fi
         done;
         echo "sites/common_site_config.json found";
-        bench new-site --mariadb-user-host-login-scope='%' --admin-password=admin --db-root-username=root --db-root-password=admin --install-app erpnext --set-default frontend --force;
+        if [ -d "sites/frontend" ]; then
+          echo "Site frontend already exists, skipping creation";
+        else
+          bench new-site --mariadb-user-host-login-scope='%' --admin-password=admin --db-root-username=root --db-root-password=admin --install-app erpnext --set-default frontend;
+        fi;
 
   db:
     image: mariadb:11.8


### PR DESCRIPTION
## Summary
Fixes two issues in `pwd.yml`:

1. **`create-site` fails** with "Site frontend already exists" on re-runs - now checks if site exists first
2. **Backend fails** with "Module Core not found" - missing `depends_on: configurator` for backend services

## Changes
- Added `depends_on: configurator: condition: service_completed_successfully` to:
  - `backend`
  - `queue-long`
  - `queue-short`
  - `scheduler`
  - `websocket`
- Added `backend` dependency to `frontend` service
- `create-site` now checks for existing `sites/frontend` directory before creating site (avoids data loss from `--force`)

## Root Cause
Without `sites/apps.txt` (created by `configurator`), Frappe can't find installed apps (frappe, erpnext), causing "Module Core not found".

Fixes #1943