### PR TITLE
fix(actions): replace deprecated pre-commit-autoupdate

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -12,8 +12,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.x"
+
       - name: Update pre-commit hooks
-        uses: vrslev/pre-commit-autoupdate@v1.0.0
+        run: |
+          python -m pip install --upgrade pre-commit
+          pre-commit autoupdate
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
Replaces the deprecated `vrslev/pre-commit-autoupdate@v1.0.0` action.

Causes:
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```
