### PR TITLE
fix(devcontainer): rely on VS Code port forwarding

### DIFF
--- a/devcontainer-example/devcontainer.json
+++ b/devcontainer-example/devcontainer.json
@@ -1,6 +1,24 @@
 {
   "name": "Frappe Bench",
   "forwardPorts": [8000, 9000, 6787],
+  "portsAttributes": {
+    "8000-8099": {
+      "label": "Frappe web",
+      "protocol": "http",
+      "onAutoForward": "notify"
+    },
+    "9000-9099": {
+      "label": "Frappe realtime",
+      "onAutoForward": "silent"
+    },
+    "6787": {
+      "label": "Frappe asset watcher",
+      "onAutoForward": "silent"
+    }
+  },
+  "otherPortsAttributes": {
+    "onAutoForward": "ignore"
+  },
   "remoteUser": "frappe",
   "customizations": {
     "vscode": {
@@ -15,6 +33,10 @@
         "charliermarsh.ruff"
       ],
       "settings": {
+        "remote.autoForwardPorts": true,
+        "remote.autoForwardPortsSource": "process",
+        "remote.restoreForwardedPorts": true,
+        "remote.localPortHost": "localhost",
         "terminal.integrated.profiles.linux": {
           "frappe bash": {
             "path": "/bin/bash"

--- a/devcontainer-example/docker-compose.yml
+++ b/devcontainer-example/docker-compose.yml
@@ -52,9 +52,7 @@ services:
       # Enable if you require git cloning
       # - ${HOME}/.ssh:/home/frappe/.ssh
     working_dir: /workspace/development
-    ports:
-      - 8000-8005:8000-8005
-      - 9000-9005:9000-9005
+    # Development ports are forwarded by devcontainer.json.
   # enable the below service if you need Cypress UI Tests to be executed
   # Before enabling ensure install_x11_deps.sh has been executed and display variable is exported.
   # Run install_x11_deps.sh again if DISPLAY is not set

--- a/docs/05-development/01-development.md
+++ b/docs/05-development/01-development.md
@@ -378,7 +378,7 @@ The first command can take a few seconds to be executed, this is to be expected.
 
 ## Manually start containers
 
-In case you don't use VSCode, you may start the containers manually with the following command:
+The example configuration forwards development ports through VS Code and does not publish them through Docker. If you don't use VS Code, first follow the [CLI-only port configuration](04-alternate-setup.md#configure-ports-for-cli-only-use), then start the containers manually:
 
 ### Running the containers
 

--- a/docs/05-development/04-alternate-setup.md
+++ b/docs/05-development/04-alternate-setup.md
@@ -66,6 +66,24 @@ This gives you `.devcontainer/docker-compose.yml` which defines all the services
 - `redis-cache` — cache layer
 - `redis-queue` — background job queue
 
+### Configure ports for CLI-only use
+
+The example configuration is intended for VS Code Dev Containers and forwards development ports through VS Code. Because this setup runs Docker Compose directly, add the following environment variable and loopback-only port mappings to the `frappe` service in `.devcontainer/docker-compose.yml`:
+
+```yaml
+services:
+  frappe:
+    # ... existing config
+    environment:
+      - SHELL=/bin/bash
+      - FRAPPE_BIND_ADDR=0.0.0.0
+    ports:
+      - "127.0.0.1:8000-8005:8000-8005"
+      - "127.0.0.1:9000-9005:9000-9005"
+```
+
+Frappe's development server binds to `127.0.0.1` by default. `FRAPPE_BIND_ADDR=0.0.0.0` makes it reachable through Docker's port mappings, while binding the published ports to `127.0.0.1` keeps them accessible only from your local machine.
+
 ---
 
 ## Step 4 — Add ARM64 Platform to All Services
@@ -121,15 +139,17 @@ Error response from daemon: failed to set up container networking: driver failed
 
 - Check if the port is being used by another service with `lsof -i :PORT`
   > Usually on MacOS ports 8000 and 9000 are usually reserved for system use
-- Go to line 60 and 61 under the `frappe` service and change the ports
+- Change the host-side port ranges under the `frappe` service
 
 Eg:
 
-```
+```yaml
 ports:
-      - 8001-8005:8001-8005
-      - 9002-9005:9002-9005
+  - "127.0.0.1:8100-8105:8000-8005"
+  - "127.0.0.1:9100-9105:9000-9005"
 ```
+
+With this example, open the first site on port `8100` instead of `8000`.
 
 ---
 


### PR DESCRIPTION
# Summary
Adapt the development setup to Frappe’s new localhost-only development server binding introduced by frappe/frappe#41516.
The devcontainer now relies on VS Code port forwarding instead of Docker-published ports.
# Changes
- Remove Docker port mappings for development ports.
- Always forward the primary ports:
    - 8000 — Frappe web
    - 9000 — Frappe realtime
    - 6787 — asset watcher

- Automatically forward additional Frappe services within:
    - 8000-8099 for web servers
    - 9000-9099 for realtime servers

- Ignore unrelated automatically detected ports.
- Explicitly configure VS Code’s port-forwarding behavior.
- Update CLI-only development documentation to explain how to:
    - set FRAPPE_BIND_ADDR=0.0.0.0;
    - publish the required ports through Docker;
    - restrict published ports to host loopback.

# Rationale
VS Code forwarded ports appear as localhost connections inside the container, so they continue to work when Frappe binds its development server to `127.0.0.1`.
Docker-published ports do not work with a service bound only to container loopback. Developers running the Compose setup without VS Code must therefore explicitly change the Frappe bind address and publish the required ports.
Production setups are unaffected because the production container runs Gunicorn with an explicit `0.0.0.0:8000` binding.