### PR TITLE
fix(tests): grant MariaDB site access broadly

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,7 @@ def frappe_site(compose: Compose):
     site_name = "tests.localhost"
     compose.bench(
         "new-site",
-        # TODO: change to --mariadb-user-host-login-scope=%
+        "--mariadb-user-host-login-scope=%",
         "--no-mariadb-socket",
         "--db-root-password=123",
         "--admin-password=admin",
@@ -97,7 +97,7 @@ def erpnext_site(compose: Compose):
     site_name = "test-erpnext-site.localhost"
     args = [
         "new-site",
-        # TODO: change to --mariadb-user-host-login-scope=%
+        "--mariadb-user-host-login-scope=%",
         "--no-mariadb-socket",
         "--db-root-password=123",
         "--admin-password=admin",

--- a/tests/test_site_creation.py
+++ b/tests/test_site_creation.py
@@ -1,0 +1,30 @@
+import pytest
+
+from tests import conftest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def frappe_setup():
+    yield
+
+
+class FakeCompose:
+    def __init__(self):
+        self.bench_calls = []
+        self.compose_calls = []
+
+    def __call__(self, *cmd):
+        self.compose_calls.append(cmd)
+
+    def bench(self, *cmd):
+        self.bench_calls.append(cmd)
+
+
+@pytest.mark.parametrize("fixture", (conftest.frappe_site, conftest.erpnext_site))
+def test_mariadb_site_creation_allows_all_container_hosts(fixture):
+    compose = FakeCompose()
+    site = fixture.__wrapped__(compose)
+
+    next(site)
+
+    assert "--mariadb-user-host-login-scope=%" in compose.bench_calls[0]


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Fixes MariaDB site creation coverage so Docker test sites grant access from all container hosts, matching the documented `bench new-site --mariadb-user-host-login-scope=%` usage. This protects backend, scheduler, and queue containers from receiving a DB user limited to only the creating container IP.

Verification:
- `python3 -m pytest tests/test_site_creation.py -q`
- `python3 -m py_compile tests/conftest.py tests/test_site_creation.py`

Closes #1952