### PR TITLE
fix(actions): sign pre-commit autoupdate commits

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -31,3 +31,4 @@ jobs:
           body: Update pre-commit hooks
           labels: dependencies,development
           delete-branch: True
+          sign-commits: true


### PR DESCRIPTION
## Summary

Sign commits created by the pre-commit autoupdate workflow using `github-actions[bot]`.

This avoids attributing automated commits to the `github.actor` associated with scheduled workflow runs and gives the generated commits a verified bot identity.