### PR TITLE
chore(deps): improve Dependabot update configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,24 +3,47 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: docker
     directory: images/bench
     schedule:
-      interval: daily
-
-  - package-ecosystem: docker
-    directory: images/production
-    schedule:
-      interval: daily
-
-  - package-ecosystem: docker
-    directory: images/custom
-    schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /docs
+    schedule:
+      interval: weekly
+    groups:
+      docs-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      pre-commit-hooks:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker-compose
+    directory: /devcontainer-example
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Refine Dependabot configuration to reduce update noise and improve dependency coverage.

- run routine dependency updates weekly instead of daily
- group minor and patch GitHub Actions updates
- add dependency updates for the docs pnpm project
- add Docker Compose updates for the devcontainer example
- add pre-commit hook updates
- remove Docker update entries that rely on parameterized base images
