### PR TITLE
fix: pin pnpm major in base images

### DIFF
--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -15,6 +15,15 @@ ENV NVM_DIR=/home/frappe/.nvm
 ENV NVM_SYMLINK_CURRENT=true
 ENV PATH=${NVM_DIR}/current/bin/:${PATH}
 
+# pnpm is provided through Corepack. Left unpinned, Corepack resolves the
+# newest pnpm (12.x at the time of writing), whose build-script policy breaks
+# `pnpm install` in Frappe apps that expect pnpm 10 (e.g. frappe/drive).
+# Pin the major those apps target and share the Corepack cache with the
+# frappe user so the pin applies in every stage.
+ARG PNPM_VERSION=10.34.5
+ENV COREPACK_HOME=/usr/local/share/corepack
+ENV COREPACK_DEFAULT_TO_LATEST=0
+
 RUN useradd -ms /bin/bash frappe \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -51,6 +60,7 @@ RUN useradd -ms /bin/bash frappe \
     && nvm use ${NODE_VERSION} \
     && npm install -g yarn \
     && corepack enable pnpm \
+    && corepack install -g pnpm@${PNPM_VERSION} \
     && nvm alias default ${NODE_VERSION} \
     && rm -rf ${NVM_DIR}/.cache \
     && echo 'export NVM_DIR="/home/frappe/.nvm"' >>/home/frappe/.bashrc \

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -11,6 +11,15 @@ ENV NVM_DIR=/home/frappe/.nvm
 ENV NVM_SYMLINK_CURRENT=true
 ENV PATH=${NVM_DIR}/current/bin/:${PATH}
 
+# pnpm is provided through Corepack. Left unpinned, Corepack resolves the
+# newest pnpm (12.x at the time of writing), whose build-script policy breaks
+# `pnpm install` in Frappe apps that expect pnpm 10 (e.g. frappe/drive).
+# Pin the major those apps target and share the Corepack cache with the
+# frappe user so the pin applies in every stage.
+ARG PNPM_VERSION=10.34.5
+ENV COREPACK_HOME=/usr/local/share/corepack
+ENV COREPACK_DEFAULT_TO_LATEST=0
+
 RUN useradd -ms /bin/bash frappe \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -47,6 +56,7 @@ RUN useradd -ms /bin/bash frappe \
     && nvm use ${NODE_VERSION} \
     && npm install -g yarn \
     && corepack enable pnpm \
+    && corepack install -g pnpm@${PNPM_VERSION} \
     && nvm alias default ${NODE_VERSION} \
     && rm -rf ${NVM_DIR}/.cache \
     && echo 'export NVM_DIR="/home/frappe/.nvm"' >>/home/frappe/.bashrc \


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Since #1808 the base images expose pnpm through Corepack (`corepack enable pnpm`) so that apps whose install step needs pnpm, such as `frappe/drive`, can build. Corepack is left to resolve the pnpm version itself, and with no `packageManager` field in those apps it downloads whatever the registry's `latest` tag points at. As of early September 2026 that is pnpm 12.x.

pnpm 10 introduced a policy of refusing to run dependency build scripts unless they are allow-listed, and pnpm 12 reads that allow-list differently from pnpm 10. `frappe/drive` targets pnpm 10 (its `scripts/install-pnpm.sh` installs `pnpm@latest-10`, and its `pnpm-workspace.yaml` allow-list is written for pnpm 10). Under Corepack-resolved pnpm 12 its postinstall now fails and aborts `bench init`:

```
Error: ERR_PNPM_IGNORED_BUILDS
  × installing dependencies
  ╰─▶ Ignored build scripts: @parcel/watcher@2.5.1, @swc/core@1.13.3,
      canvas@2.11.2, core-js@3.44.0, esbuild@0.18.20, esbuild@0.25.9, vue-demi@0.14.10
  help: Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
...
bench.exceptions.CommandFailedError: yarn install --check-files --verbose
ERROR: There was a problem while creating /home/frappe/frappe-bench
```

The `frappe/build:version-15` image published on 2026-09-08 already ships the Corepack shim that resolves to pnpm 12.3.4, so any `images/layered` or `images/custom` build that includes drive fails today.

> Explain the **details** for making this change. What existing problem does the pull request solve?

This pins the pnpm major line that Frappe apps currently target instead of floating on `latest`:

- `ARG PNPM_VERSION=10.34.5` in the base stage of `images/custom/Containerfile` and `images/production/Containerfile`, overridable with `--build-arg`. Corepack also accepts dist-tags, so `--build-arg PNPM_VERSION=latest-10` works for anyone who prefers a floating major.
- `corepack install -g pnpm@${PNPM_VERSION}` right after `corepack enable pnpm`, so the pinned binary is downloaded at image build time rather than on first use.
- `ENV COREPACK_HOME=/usr/local/share/corepack`. Corepack's default cache is per user (`~/.cache/node/corepack`). The base stage runs as root but `bench init` runs as `frappe`, so without a shared location the pin would not be visible where it matters.
- `ENV COREPACK_DEFAULT_TO_LATEST=0` so Corepack does not silently move off the pinned version when the registry's `latest` advances again.

`npm install -g pnpm@…` was considered and rejected: on the current images it does not displace the Corepack shim that owns `bin/pnpm`, so the shim (and therefore pnpm 12) still wins. `corepack install -g` is the mechanism Corepack provides for exactly this.

Verified by:

- Building the `base` target of `images/production/Containerfile` with this change and confirming `pnpm --version` prints `10.34.5` as the `frappe` user.
- Applying the equivalent pin (`corepack install -g pnpm@10.34.5` as `frappe`, plus `COREPACK_DEFAULT_TO_LATEST=0`) in `images/layered/Containerfile` on top of the published `frappe/build:version-15` image and running a full `bench init` with `frappe`, `erpnext`, `hrms`, `crm`, `insights`, `print_designer`, `drive`, `raven` and `builder`. All nine apps installed and the image built and ran.

No behaviour changes for apps that do not use pnpm.
